### PR TITLE
Fix loopback typo

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -13558,7 +13558,7 @@ static ma_result ma_device_stop__wasapi(ma_device* pDevice)
     In loopback mode it's possible for WaitForSingleObject() to get stuck in a deadlock when nothing is being played. When nothing
     is being played, the event is never signalled internally by WASAPI which means we will deadlock when stopping the device.
     */
-    if (pDevice->type == ma_device_type_capture || pDevice->type == ma_device_type_duplex || pDevice->type == ma_device_type_duplex) {
+    if (pDevice->type == ma_device_type_capture || pDevice->type == ma_device_type_duplex || pDevice->type == ma_device_type_loopback) {
         SetEvent((HANDLE)pDevice->wasapi.hEventCapture);
     }
 


### PR DESCRIPTION
Hello,

I found a typo while investigating a hang on loopback device close.

Also had a question regarding the comment in ma_device_stop__wasapi ("possible for WaitForSingleObject() to get stuck..."). Does the setEvent below the comment take care of the deadlock you describe or do I have to do something to make sure the deadlock doesn't happen? (and if it's the latter, what do you suggest I do?)

Thanks!