### PR TITLE
get channel count also from coreaudio format-list

### DIFF
--- a/examples/simple_enumeration.c
+++ b/examples/simple_enumeration.c
@@ -35,14 +35,24 @@ int main(int argc, char** argv)
 
     printf("Playback Devices\n");
     for (iDevice = 0; iDevice < playbackDeviceCount; ++iDevice) {
-        printf("    %u: %s\n", iDevice, pPlaybackDeviceInfos[iDevice].name);
+        ma_device_info * info = &pPlaybackDeviceInfos[iDevice];
+        printf("    %u: %s\n", iDevice, info->name);
+
+        // (optional) get detailed info
+        ma_context_get_device_info(&context, ma_device_type_playback, &info->id, ma_share_mode_shared, info);
+        printf("    %u - %u kHz, %u - %u channels\n", info->minSampleRate, info->maxSampleRate, info->minChannels, info->maxChannels);
     }
 
     printf("\n");
 
     printf("Capture Devices\n");
     for (iDevice = 0; iDevice < captureDeviceCount; ++iDevice) {
-        printf("    %u: %s\n", iDevice, pCaptureDeviceInfos[iDevice].name);
+        ma_device_info * info = &pCaptureDeviceInfos[iDevice];
+        printf("    %u: %s\n", iDevice, info->name);
+
+        // (optional) get detailed info
+        ma_context_get_device_info(&context, ma_device_type_capture, &info->id, ma_share_mode_shared, info);
+        printf("    %u - %u kHz, %u - %u channels\n", info->minSampleRate, info->maxSampleRate, info->minChannels, info->maxChannels);
     }
 
 


### PR DESCRIPTION
this is a possible fix for #205 

there are two changes in this commit: 

* get number of channels from the coreaudio format list
* update simple_enumeration example to list more detailed output (channel and samplerate ranges)

i might have been a bit over-excessive with the range checking, on my computer the output is as follows:

	2020-10-13 15:30:03.332678+0200 simple_enumeration[11902:842283]   saved enable noise cancellation setting is the same as the default (=0)
	[miniaudio] Endian:  LE
	[miniaudio] SSE2:    YES
	[miniaudio] AVX2:    NO
	[miniaudio] AVX512F: NO
	[miniaudio] NEON:    NO
	Playback Devices
	    0: Built-in Output
	    44100 - 96000 kHz, 2 - 2 channels
	    1: BlackHole 16ch
	    44100 - 192000 kHz, 2 - 16 channels
	    2: Soundflower (2ch)
	    44100 - 192000 kHz, 2 - 2 channels
	    3: Soundflower (64ch)
	WARNING: The minimum channel count of a device is above MA_MAX_CHANNELS.
	WARNING: The maximum channel count of a device is above MA_MAX_CHANNELS.
	    44100 - 192000 kHz, 32 - 32 channels
	    4: Multiausgangsgerät
	    44100 - 96000 kHz, 2 - 2 channels

	Capture Devices
	    0: Built-in Microphone
	    44100 - 96000 kHz, 2 - 2 channels
	    1: BlackHole 16ch
	    44100 - 192000 kHz, 2 - 16 channels
	    2: Soundflower (2ch)
	    44100 - 192000 kHz, 2 - 2 channels
	    3: Soundflower (64ch)
	WARNING: The minimum channel count of a device is above MA_MAX_CHANNELS.
	WARNING: The maximum channel count of a device is above MA_MAX_CHANNELS.
	    44100 - 192000 kHz, 32 - 32 channels
	Program ended with exit code: 0


--- 

**NOTE:** going through the code i noticed a funky thing that could happen before, and even though unlikely i think it could still happen on mobile and possibly other platforms: 

1. assume the channel count is >MA_MAX_CHANNELS, eg. 64>32 on my system 
2. ma_context_get_device_info__coreaudio will return minChannels=maxChannels=64
3. when the code bubbles back up into `ma_context_get_device_info` the following will happen: 

        deviceInfo.minChannels   = ma_max(deviceInfo.minChannels,   MA_MIN_CHANNELS); // now minChannels=64
        deviceInfo.maxChannels   = ma_min(deviceInfo.maxChannels,   MA_MAX_CHANNELS); // now maxChannels=32


i think moving my entire `if(minChannels<MA_MIN_CHANNELS){warn...}` etc block into `ma_context_get_device_info` could make sense. then it's guaranteed to be checked for all implementations and at least developers should see that they have a device with more channels than miniaudio is configured for (i feel dumb, but i compile with 128 channels now to support all the weird configurations i came across). 