### PR TITLE
Fix intermediaryBufferView losing reference to wasm memory after heap resize

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -31283,6 +31283,11 @@ static ma_result ma_device_init_by_type__webaudio(ma_context* pContext, const ma
                     return; /* This means the device has been uninitialized. */
                 }
 
+                if(device.intermediaryBufferView.length == 0) {
+                    /* Recreate intermediaryBufferView when losing reference to the underlying buffer, probably due to emscripten resizing heap. */
+                    device.intermediaryBufferView = new Float32Array(Module.HEAPF32.buffer, device.intermediaryBuffer, device.intermediaryBufferSizeInBytes);
+                }
+
                 /* Make sure silence it output to the AudioContext destination. Not doing this will cause sound to come out of the speakers! */
                 for (var iChannel = 0; iChannel < e.outputBuffer.numberOfChannels; ++iChannel) {
                     e.outputBuffer.getChannelData(iChannel).fill(0.0);
@@ -31341,6 +31346,11 @@ static ma_result ma_device_init_by_type__webaudio(ma_context* pContext, const ma
             device.scriptNode.onaudioprocess = function(e) {
                 if (device.intermediaryBuffer === undefined) {
                     return; /* This means the device has been uninitialized. */
+                }
+
+                if(device.intermediaryBufferView.length == 0) {
+                    /* Recreate intermediaryBufferView when losing reference to the underlying buffer, probably due to emscripten resizing heap. */
+                    device.intermediaryBufferView = new Float32Array(Module.HEAPF32.buffer, device.intermediaryBuffer, device.intermediaryBufferSizeInBytes);
                 }
 
                 var outputSilence = false;


### PR DESCRIPTION
First I want to thank you for this awesome project!

Have a fix I would like to contribute back if possible:
When miniaudio initializes audio context it stores a buffer view to wasm heap:
```javascript 
device.intermediaryBufferView = new Float32Array(Module.HEAPF32.buffer, device.intermediaryBuffer, device.intermediaryBufferSizeInBytes);
```

When emscripten grows it's heap it seems to recreate the underlying buffer thus making all views, inclusive `device.intermediaryBufferView` point to nothing. 

The fix I found is to recreate the view after a heap resize like emscripten does internally:
```javascript

function emscripten_realloc_buffer(size) {
        ...
        wasmMemory.grow((size - buffer.byteLength + 65535) >>> 16); // .grow() takes a delta compared to the previous size
        updateGlobalBufferAndViews(wasmMemory.buffer);
        ...
}

function updateGlobalBufferAndViews(buf) {
    buffer = buf;
    ...
    Module['HEAPF32'] = HEAPF32 = new Float32Array(buf);
    ...
}
```

It doesn't seem that emscripten is generating events for when it is resizing the heap that we can check. But I found that just checking the buffer view length property seems to work fine. It always seem to be 0 when the ref is lost.  Have tested the fix in both chrome and firefox.