### PR TITLE
added dynamic amplitude, seed, type to noise generation

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -1190,6 +1190,9 @@ miniaudio supports generation of white, pink and Brownian noise via the `ma_nois
 The noise API uses simple LCG random number generation. It supports a custom seed which is useful for things like automated testing requiring reproducibility.
 Setting the seed to zero will default to MA_DEFAULT_LCG_SEED.
 
+The amplitude, seed, and type can be changed dynamically with `ma_noise_set_amplitude()`, `ma_noise_set_seed()`,
+and `ma_noise_set_type()` respectively.
+
 By default, the noise API will use different values for different channels. So, for example, the left side in a stereo stream will be different to the right
 side. To instead have each channel use the same random value, set the `duplicateChannels` member of the noise config to true, like so:
 
@@ -6107,8 +6110,6 @@ MA_API ma_result ma_waveform_set_frequency(ma_waveform* pWaveform, double freque
 MA_API ma_result ma_waveform_set_type(ma_waveform* pWaveform, ma_waveform_type type);
 MA_API ma_result ma_waveform_set_sample_rate(ma_waveform* pWaveform, ma_uint32 sampleRate);
 
-
-
 typedef enum
 {
     ma_noise_type_white,
@@ -6149,6 +6150,11 @@ typedef struct
 } ma_noise;
 
 MA_API ma_result ma_noise_init(const ma_noise_config* pConfig, ma_noise* pNoise);
+MA_API ma_result ma_noise_set_amplitude(ma_noise* pNoise, double amplitude);
+MA_API ma_result ma_noise_set_seed(ma_noise* pNoise, ma_uint32 seed);
+MA_API ma_result ma_noise_set_type(ma_noise* pNoise, ma_noise_type type);
+
+
 MA_API ma_uint64 ma_noise_read_pcm_frames(ma_noise* pNoise, void* pFramesOut, ma_uint64 frameCount);
 
 #endif  /* MA_NO_GENERATION */
@@ -48428,6 +48434,37 @@ MA_API ma_result ma_noise_init(const ma_noise_config* pConfig, ma_noise* pNoise)
         }
     }
 
+    return MA_SUCCESS;
+}
+
+MA_API ma_result ma_noise_set_amplitude(ma_noise* pNoise, double amplitude)
+{
+    if (pNoise == NULL) {
+        return MA_INVALID_ARGS;
+    }
+
+    pNoise->config.amplitude = amplitude;
+    return MA_SUCCESS;
+}
+
+MA_API ma_result ma_noise_set_seed(ma_noise* pNoise, ma_int32 seed)
+{
+    if (pNoise == NULL) {
+        return MA_INVALID_ARGS;
+    }
+
+    pNoise->lcg.state = seed;
+    return MA_SUCCESS;
+}
+
+
+MA_API ma_result ma_noise_set_type(ma_noise* pNoise, ma_noise_type type)
+{
+    if (pNoise == NULL) {
+        return MA_INVALID_ARGS;
+    }
+
+    pNoise->config.type = type;
     return MA_SUCCESS;
 }
 

--- a/miniaudio.h
+++ b/miniaudio.h
@@ -6150,12 +6150,10 @@ typedef struct
 } ma_noise;
 
 MA_API ma_result ma_noise_init(const ma_noise_config* pConfig, ma_noise* pNoise);
+MA_API ma_uint64 ma_noise_read_pcm_frames(ma_noise* pNoise, void* pFramesOut, ma_uint64 frameCount);
 MA_API ma_result ma_noise_set_amplitude(ma_noise* pNoise, double amplitude);
 MA_API ma_result ma_noise_set_seed(ma_noise* pNoise, ma_uint32 seed);
 MA_API ma_result ma_noise_set_type(ma_noise* pNoise, ma_noise_type type);
-
-
-MA_API ma_uint64 ma_noise_read_pcm_frames(ma_noise* pNoise, void* pFramesOut, ma_uint64 frameCount);
 
 #endif  /* MA_NO_GENERATION */
 


### PR DESCRIPTION
This PR adds dynamic properties to the noise generation API. Setting the seed dynamically does result in subtle changes to the noise generation, and I have been able to lerp across seed values to produce new sound.