### PR TITLE
docs: fix simple typo, priorties -> priorities

### DIFF
--- a/extras/miniaudio_split/miniaudio.h
+++ b/extras/miniaudio_split/miniaudio.h
@@ -456,7 +456,7 @@ typedef struct
 
 
 #ifndef MA_NO_THREADING
-/* Thread priorties should be ordered such that the default priority of the worker thread is 0. */
+/* Thread priorities should be ordered such that the default priority of the worker thread is 0. */
 typedef enum
 {
     ma_thread_priority_idle     = -5,

--- a/miniaudio.h
+++ b/miniaudio.h
@@ -1883,7 +1883,7 @@ typedef struct
 
 
 #ifndef MA_NO_THREADING
-/* Thread priorties should be ordered such that the default priority of the worker thread is 0. */
+/* Thread priorities should be ordered such that the default priority of the worker thread is 0. */
 typedef enum
 {
     ma_thread_priority_idle     = -5,


### PR DESCRIPTION
There is a small typo in extras/miniaudio_split/miniaudio.h, miniaudio.h.

Should read `priorities` rather than `priorties`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md