### PR TITLE
Fix sound seek in miniaudio engine

### DIFF
--- a/research/miniaudio_engine.h
+++ b/research/miniaudio_engine.h
@@ -8099,11 +8099,12 @@ static void ma_engine_mix_sound_internal(ma_engine* pEngine, ma_sound_group* pGr
 
     /* If we're seeking, do so now before reading. */
     if (pSound->seekTarget != MA_SEEK_TARGET_NONE) {
-        pSound->seekTarget  = MA_SEEK_TARGET_NONE;
         ma_data_source_seek_to_pcm_frame(pSound->pDataSource, pSound->seekTarget);
                 
         /* Any time-dependant effects need to have their times updated. */
         ma_engine_effect_set_time(&pSound->effect, pSound->seekTarget);
+
+        pSound->seekTarget  = MA_SEEK_TARGET_NONE;
     }
 
     /* If the sound is being delayed we don't want to mix anything, nor do we want to advance time forward from the perspective of the data source. */


### PR DESCRIPTION
This fixes `ma_sound_seek_to_pcm_frame` in miniaudio engine. It was not working due to `seekTarget` being set to `MA_SEEK_TARGET_NONE` before actually using it.