### PR TITLE
fix iOS deadlocks

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -25653,7 +25653,7 @@ static ma_result ma_device__untrack__coreaudio(ma_device* pDevice)
 
 -(void)remove_handler
 {
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"AVAudioSessionRouteChangeNotification" object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:AVAudioSessionRouteChangeNotification object:nil];
 }
 
 -(void)handle_route_change:(NSNotification*)pNotification


### PR DESCRIPTION
We need to fix name in `[NSNotificationCenter defaultCenter] removeObserver:self ...` which is incorrect and leads to deadlock on any notification (for example `[[NSUserDefaults standardUserDefaults] setInteger ...` ), because observer address is not valid after `dealloc`