### PR TITLE
wasapi: ensure that wasapi context structure is zeroed before filling it

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -16257,6 +16257,8 @@ static ma_result ma_context_init__wasapi(ma_context* pContext, const ma_context_
         return result;
     }
 
+    MA_ZERO_OBJECT(&pContext->wasapi);
+
     /*
     Annoyingly, WASAPI does not allow you to release an IAudioClient object from a different thread
     than the one that retrieved it with GetService(). This can result in a deadlock in two


### PR DESCRIPTION
I had a situation where I was doing:

```c
    ma_backend backends[] = {
	ma_backend_jack,
	ma_backend_wasapi,
    };
    ma_context_init(backends, sizeof(backends)/sizeof(backends[0]),
	&contextConfig, &context);
```

And since JACK was unavailable, it fell back to WASAPI. When this
happened, the WASAPI `commandIndex` and `commandCount` variables were
already stomped on by the JACK backend initialization, but the WASAPI
backend assumes they are zero-initialized.