### PR TITLE
Handle no data on read from PulseAudio instead of ASSERT

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -22629,7 +22629,9 @@ static void ma_device_on_read__pulse(ma_pa_stream* pStream, size_t byteCount, vo
     MA_ASSERT(pDevice != NULL);
 
     bpf = ma_get_bytes_per_frame(pDevice->capture.internalFormat, pDevice->capture.internalChannels);
-    MA_ASSERT(bpf > 0);
+    if (0 == bpf) {
+        return;
+    }
 
     frameCount = byteCount / bpf;
     framesProcessed = 0;


### PR DESCRIPTION
Getting `0` on read from PulseAudio happens sometimes during
recording on Raspberry Pi 4, thus ASSERT is not enough as
there is a divide by zero which crashes the application.