### PR TITLE
Reorder examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,42 @@
 
 Examples
 ========
+
+This example shows one way to play a sound using the high level API.
+
+```c
+#define MINIAUDIO_IMPLEMENTATION
+#include "../miniaudio.h"
+
+#include <stdio.h>
+
+int main(int argc, char** argv)
+{
+    ma_result result;
+    ma_engine engine;
+
+    if (argc < 2) {
+        printf("No input file.");
+        return -1;
+    }
+
+    result = ma_engine_init(NULL, &engine);
+    if (result != MA_SUCCESS) {
+        printf("Failed to initialize audio engine.");
+        return -1;
+    }
+
+    ma_engine_play_sound(&engine, argv[1], NULL);
+
+    printf("Press Enter to quit...");
+    getchar();
+
+    ma_engine_uninit(&engine);
+
+    return 0;
+}
+```
+
 This example shows how to decode and play a sound using the low level API.
 
 ```c
@@ -84,41 +120,6 @@ int main(int argc, char** argv)
 
     ma_device_uninit(&device);
     ma_decoder_uninit(&decoder);
-
-    return 0;
-}
-```
-
-This example shows one way to play a sound using the high level API.
-
-```c
-#define MINIAUDIO_IMPLEMENTATION
-#include "../miniaudio.h"
-
-#include <stdio.h>
-
-int main(int argc, char** argv)
-{
-    ma_result result;
-    ma_engine engine;
-
-    if (argc < 2) {
-        printf("No input file.");
-        return -1;
-    }
-
-    result = ma_engine_init(NULL, &engine);
-    if (result != MA_SUCCESS) {
-        printf("Failed to initialize audio engine.");
-        return -1;
-    }
-
-    ma_engine_play_sound(&engine, argv[1], NULL);
-
-    printf("Press Enter to quit...");
-    getchar();
-
-    ma_engine_uninit(&engine);
 
     return 0;
 }


### PR DESCRIPTION
I doubt the majority of users will need the extra control that the low-level API provides, so it make sense to show the high-level API first so it's:
- "This is how simple using the library is"
- "This is how much control you can get if you want"

Reduces the risk of people seeing the first example and going "man, this is verbose..."
