### PR TITLE
Fix UB when there are no audio devices

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -39913,7 +39913,12 @@ MA_API ma_result ma_context_get_devices(ma_context* pContext, ma_device_info** p
 
             /* Capture devices. */
             if (ppCaptureDeviceInfos != NULL) {
-                *ppCaptureDeviceInfos = pContext->pDeviceInfos + pContext->playbackDeviceInfoCount; /* Capture devices come after playback devices. */
+                *ppCaptureDeviceInfos = pContext->pDeviceInfos;
+                /* Capture devices come after playback devices. */
+                if (pContext->playbackDeviceInfoCount > 0) {
+                    /* Conditional, because NULL+0 is undefined behavior. */
+                    *ppCaptureDeviceInfos += pContext->playbackDeviceInfoCount;
+                }
             }
             if (pCaptureDeviceCount != NULL) {
                 *pCaptureDeviceCount = pContext->captureDeviceInfoCount;


### PR DESCRIPTION
When there are no capture nor playback devices, `pContext->pDeviceInfos` is `NULL` and `pContext->playbackDeviceInfoCount` is 0. Unfortunately, any arithmetic on `NULL` is UB, including trivial `+0`, which triggers UB sanitizer. This can lead to crashes, for example when compiling with Zig, which enables UBsan by default.

Note: this could easily be a oneliner, but the line was already long enough.
I have also wanted to include an explicit comment, because without knowing that `NULL+0` is UB, the code would seem insane.

Some extra context: [SO about NULL arithmetic](https://stackoverflow.com/questions/15608366/is-performing-arithmetic-on-a-null-pointer-undefined-behavior) and [Zig issue about the same problem elsewhere](https://github.com/ziglang/zig/issues/11324).
