### PR TITLE
WebAudio: check if `window` is defined before accessing it

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -38952,7 +38952,7 @@ static ma_result ma_context_init__webaudio(ma_context* pContext, const ma_contex
 
     /* Here is where our global JavaScript object is initialized. */
     resultFromJS = EM_ASM_INT({
-        if ((window.AudioContext || window.webkitAudioContext) === undefined) {
+        if (typeof window === 'undefined' || (window.AudioContext || window.webkitAudioContext) === undefined) {
             return 0;   /* Web Audio not supported. */
         }
 


### PR DESCRIPTION
In certain environments (WebWorkers for instance) `window` is undefined. Accessing it will lead to an `Uncaught ReferenceError` that can't be handled by the calling C code. That's why I added a check that will return 0 in such a case.
