### PR TITLE
Add ma_pulsewave Generator Type

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -10118,8 +10118,8 @@ MA_API ma_pulsewave_config ma_pulsewave_config_init(ma_format format, ma_uint32 
 
 typedef struct
 {
-    ma_pulsewave_config config;
     ma_waveform waveform;
+    ma_pulsewave_config config;
 } ma_pulsewave;
 
 MA_API ma_result ma_pulsewave_init(const ma_pulsewave_config* pConfig, ma_pulsewave* pWaveform);


### PR DESCRIPTION
Adds a `ma_pulsewave` generator type to allow a pulse wave with a custom duty cycle. It does not change or break any existing `ma_waveform_type_square` implementations and is/should be 100% backward-compatible. Under the hood, `ma_pulsewave` is a thin wrapper around a `ma_waveform` of type `ma_waveform_type_square.` The `dutyCycle` is defaulted to `0.5` for `ma_waveform` square waves, and for `ma_pulsewave` is plumbed through accordingly.

Let me know if you'd like to not wrap things like this. It seemed prudent to use as much code as was there as it's been tested and reviewed. I did this to add the API I was looking for but wanted to retain backward compatibility. e.g., a squarewave is a pulse wave, but this inversion allows for the least surface area change.
