### PR TITLE
Discussion: Only apply `masterVolumeFactor` to output, and not input.

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -18755,7 +18755,7 @@ static void ma_device__handle_data_callback(ma_device* pDevice, void* pFramesOut
                         framesToProcessThisIteration = sizeof(tempFramesIn)/bpfCapture;
                     }
 
-                    ma_copy_and_apply_volume_factor_pcm_frames(tempFramesIn, ma_offset_ptr(pFramesIn, totalFramesProcessed*bpfCapture), framesToProcessThisIteration, pDevice->capture.format, pDevice->capture.channels, masterVolumeFactor);
+                    ma_copy_and_apply_volume_factor_pcm_frames(tempFramesIn, ma_offset_ptr(pFramesIn, totalFramesProcessed*bpfCapture), framesToProcessThisIteration, pDevice->capture.format, pDevice->capture.channels, 1.f);
 
                     ma_device__on_data(pDevice, ma_offset_ptr(pFramesOut, totalFramesProcessed*bpfPlayback), tempFramesIn, framesToProcessThisIteration);
 
@@ -18768,9 +18768,9 @@ static void ma_device__handle_data_callback(ma_device* pDevice, void* pFramesOut
             /* Volume control and clipping for playback devices. */
             if (pFramesOut != NULL) {
                 if (masterVolumeFactor < 1) {
-                    if (pFramesIn == NULL) {    /* <-- In full-duplex situations, the volume will have been applied to the input samples before the data callback. Applying it again post-callback will incorrectly compound it. */
+                    // if (pFramesIn == NULL) {    /* <-- In full-duplex situations, the volume will have been applied to the input samples before the data callback. Applying it again post-callback will incorrectly compound it. */
                         ma_apply_volume_factor_pcm_frames(pFramesOut, frameCount, pDevice->playback.format, pDevice->playback.channels, masterVolumeFactor);
-                    }
+                    // }
                 }
 
                 if (!pDevice->noClip && pDevice->playback.format == ma_format_f32) {


### PR DESCRIPTION
I am opening this up as a discussion - if we decide this is a good way to go, I will happily clean this up or leave it to you @mackron , whichever you'd prefer.

I am using an audio graph setup similar to the [main node graph example](https://miniaud.io/docs/examples/node_graph.html), with a `ma_data_source_node` whose `ma_data_source` is a `ma_audio_buffer_ref`, with `ma_audio_buffer_ref_set_data` receiving the input sample buffer from the device callback.

I ran into some behavior that was surprising to me. When I set `ma_device_set_master_volume` with the above setup, I found the input was being scaled according to the master volume, but the output was not. I ran into this when adding a waveform node to my graph. Because I use `ma_device_type_duplex` to initialize the device, with > 0 input channels, the master volume is not applied to the output (for the reasons you put in the comments - don't want to double-apply the volume to the input). So, even with the master volume set to zero, the waveform output is still at full volume.

I expected that the master volume would _not_ affect the input but _would_ affect the output, regardless of whether we're in duplex mode. I would expect any input node's volume to be scaled by the client with `ma_node_set_output_bus_volume`, or in non-node contexts, to be scaled in the device callback or via the input buffer.

With this shoddy code change, the node graph acts exactly like I would expect - setting the main device volume scales the output before it's sent to the device and doesn't change the volume of any inputs.

I'm sure there are good reasons for this behavior, so I'm opening this up as a discussion.