### PR TITLE
Fix: WASAPI device disconnection state

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -76062,6 +76062,13 @@ MA_API ma_result ma_sound_start(ma_sound* pSound)
         return MA_INVALID_ARGS;
     }
 
+    /* Fix: Issue #717. */
+    ma_device* device=ma_engine_get_device(pSound->engineNode.pEngine);
+    if (!device) return MA_INVALID_DEVICE_CONFIG;
+
+    ma_device_state state=ma_device_get_state(device);
+    if (state!=ma_device_state_started) return MA_DEVICE_NOT_STARTED;
+
     /* If the sound is already playing, do nothing. */
     if (ma_sound_is_playing(pSound)) {
         return MA_SUCCESS;


### PR DESCRIPTION
This PR fixes issue 717, where MiniAudio hangs after device disconnection using WASAPI. The ma_sound_start function now checks for ma_device_state_started with all its other validations before starting the node.

I'm new to contributing to open-source projects and this is my first pull request. I'm open to feedback and would appreciate any suggestions for improvements. Thank you!
