### PR TITLE
Fix SSE2 sample swapping in mono expansion.

### DIFF
--- a/extras/miniaudio_split/miniaudio.c
+++ b/extras/miniaudio_split/miniaudio.c
@@ -41417,7 +41417,7 @@ static ma_result ma_channel_map_apply_mono_in_f32(float* MA_RESTRICT pFramesOut,
                                 for (iFrame = 0; iFrame < unrolledFrameCount; iFrame += 1) {
                                     __m128 in0 = _mm_set1_ps(pFramesIn[iFrame*2 + 0]);
                                     __m128 in1 = _mm_set1_ps(pFramesIn[iFrame*2 + 1]);
-                                    _mm_storeu_ps(&pFramesOut[iFrame*4 + 0], _mm_shuffle_ps(in1, in0, _MM_SHUFFLE(0, 0, 0, 0)));
+                                    _mm_storeu_ps(&pFramesOut[iFrame*4 + 0], _mm_shuffle_ps(in0, in1, _MM_SHUFFLE(0, 0, 0, 0)));
                                 }
 
                                 /* Tail. */
@@ -41443,7 +41443,7 @@ static ma_result ma_channel_map_apply_mono_in_f32(float* MA_RESTRICT pFramesOut,
                                     __m128 in1 = _mm_set1_ps(pFramesIn[iFrame*2 + 1]);
 
                                     _mm_storeu_ps(&pFramesOut[iFrame*12 + 0], in0);
-                                    _mm_storeu_ps(&pFramesOut[iFrame*12 + 4], _mm_shuffle_ps(in1, in0, _MM_SHUFFLE(0, 0, 0, 0)));
+                                    _mm_storeu_ps(&pFramesOut[iFrame*12 + 4], _mm_shuffle_ps(in0, in1, _MM_SHUFFLE(0, 0, 0, 0)));
                                     _mm_storeu_ps(&pFramesOut[iFrame*12 + 8], in1);
                                 }
 

--- a/miniaudio.h
+++ b/miniaudio.h
@@ -52835,7 +52835,7 @@ static ma_result ma_channel_map_apply_mono_in_f32(float* MA_RESTRICT pFramesOut,
                                 for (iFrame = 0; iFrame < unrolledFrameCount; iFrame += 1) {
                                     __m128 in0 = _mm_set1_ps(pFramesIn[iFrame*2 + 0]);
                                     __m128 in1 = _mm_set1_ps(pFramesIn[iFrame*2 + 1]);
-                                    _mm_storeu_ps(&pFramesOut[iFrame*4 + 0], _mm_shuffle_ps(in1, in0, _MM_SHUFFLE(0, 0, 0, 0)));
+                                    _mm_storeu_ps(&pFramesOut[iFrame*4 + 0], _mm_shuffle_ps(in0, in1, _MM_SHUFFLE(0, 0, 0, 0)));
                                 }
 
                                 /* Tail. */
@@ -52861,7 +52861,7 @@ static ma_result ma_channel_map_apply_mono_in_f32(float* MA_RESTRICT pFramesOut,
                                     __m128 in1 = _mm_set1_ps(pFramesIn[iFrame*2 + 1]);
 
                                     _mm_storeu_ps(&pFramesOut[iFrame*12 + 0], in0);
-                                    _mm_storeu_ps(&pFramesOut[iFrame*12 + 4], _mm_shuffle_ps(in1, in0, _MM_SHUFFLE(0, 0, 0, 0)));
+                                    _mm_storeu_ps(&pFramesOut[iFrame*12 + 4], _mm_shuffle_ps(in0, in1, _MM_SHUFFLE(0, 0, 0, 0)));
                                     _mm_storeu_ps(&pFramesOut[iFrame*12 + 8], in1);
                                 }
 


### PR DESCRIPTION
The SSE2 code paths for mono expansion introduced in Version 0.11.15 mixed up the parameters of `_mm_shuffle_ps()`, which in turn caused adjacent PCM frames to be swapped in the channel-expanded output. The resulting audio corruption is particularly noticeable on low sampling rates (32,000 Hz and below), but can also be generally observed in the frequency spectrum.

A minimal example:

```c
#define MINIAUDIO_IMPLEMENTATION
#include "../miniaudio.h"

#include <stdio.h>

ma_engine engine;
FILE* engineOutput;

void data_callback(ma_device* device, void* out, const void* in, ma_uint32 frames)
{
    ma_uint32 bytes_per_frame = ma_get_bytes_per_frame(device->playback.format, device->playback.channels);
    ma_engine_read_pcm_frames(&engine, out, frames, NULL);
    if(engineOutput) {
        fwrite(out, (frames * bytes_per_frame), 1, engineOutput);
    }
    (void)in;
}

int main(int argc, char** argv)
{
    ma_result result;
    ma_device device;

    engineOutput = fopen("engine_output.snd", "wb");

    ma_device_config deviceConfig = ma_device_config_init(ma_device_type_playback);
    deviceConfig.dataCallback = data_callback;
    /* deviceConfig.playback.channels = 6; */
    result = ma_device_init(NULL, &deviceConfig, &device);
    if(result != MA_SUCCESS) {
        return 0;
    }

    ma_engine_config engineConfig = ma_engine_config_init();
    engineConfig.pDevice = &device;

    result = ma_engine_init(&engineConfig, &engine);
    if (result != MA_SUCCESS) {
        return -1;
    }

    ma_engine_play_sound(&engine, "sine.intro.flac", NULL);

    printf("Press Enter to quit...");
    getchar();

    ma_engine_uninit(&engine);

    if(engineOutput) {
        fclose(engineOutput);
    }

    return 0;
}
```

[Here is a sample input file, and the engine output without and with this fix.](https://github.com/mackron/miniaudio/files/12449180/miniaudio_mono_expansion_bug.zip) I reproduced both the swapped and the fixed behavior under MSVC, Clang, and GCC.

The frequency spectrum without the fix: 
![_](https://github.com/mackron/miniaudio/assets/2139424/c4974105-676b-47a6-9360-c781202e119d)

With the fix:
![_](https://github.com/mackron/miniaudio/assets/2139424/496b6d2d-e8f6-45f6-bd0d-0bee4a17eeed)