### PR TITLE
Fix value of 11025 Hz sample rate

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -4267,7 +4267,7 @@ typedef enum
     ma_standard_sample_rate_192000 = 192000,
 
     ma_standard_sample_rate_16000  = 16000,     /* Extreme lows */
-    ma_standard_sample_rate_11025  = 11250,
+    ma_standard_sample_rate_11025  = 11025,
     ma_standard_sample_rate_8000   = 8000,
 
     ma_standard_sample_rate_352800 = 352800,    /* Extreme highs */


### PR DESCRIPTION
Spotted a typo for the 11025 Hz sample rate in the `ma_standard_sample_rate` enum 
