### PR TITLE
Added null checks to ma_engine_listener_get_cone() and ma_sound_get_cone()

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -76480,6 +76480,10 @@ MA_API void ma_sound_get_cone(const ma_sound* pSound, float* pInnerAngleInRadian
         *pOuterGain = 0;
     }
 
+    if (pSound == NULL) {
+        return;
+    }
+
     ma_spatializer_get_cone(&pSound->engineNode.spatializer, pInnerAngleInRadians, pOuterAngleInRadians, pOuterGain);
 }
 

--- a/miniaudio.h
+++ b/miniaudio.h
@@ -75534,6 +75534,10 @@ MA_API void ma_engine_listener_get_cone(const ma_engine* pEngine, ma_uint32 list
         *pOuterGain = 0;
     }
 
+    if (pEngine == NULL || listenerIndex >= pEngine->listenerCount) {
+        return;
+    }
+
     ma_spatializer_listener_get_cone(&pEngine->listeners[listenerIndex], pInnerAngleInRadians, pOuterAngleInRadians, pOuterGain);
 }
 


### PR DESCRIPTION
Noticed `ma_engine_listener_get_cone()` was the only listener getter/setter not doing a check.
