### PR TITLE
Added ma_dsp_proc to ma_engine_node

### DIFF
--- a/extras/miniaudio_split/miniaudio.c
+++ b/extras/miniaudio_split/miniaudio.c
@@ -62900,6 +62900,11 @@ static void ma_engine_node_process_pcm_frames__general(ma_engine_node* pEngineNo
             ma_panner_process_pcm_frames(&pEngineNode->panner, pRunningFramesOut, pRunningFramesOut, framesJustProcessedOut);   /* In-place processing. */
         }
 
+        /* User callback to do processing on the data*/
+        if(pEngineNode->dspProc != NULL) {
+            pEngineNode->dspProc(pEngineNode, pRunningFramesOut, pRunningFramesOut, framesJustProcessedOut, channelsOut);
+        }
+
         /* We're done for this chunk. */
         totalFramesProcessedIn  += framesJustProcessedIn;
         totalFramesProcessedOut += framesJustProcessedOut;

--- a/extras/miniaudio_split/miniaudio.h
+++ b/extras/miniaudio_split/miniaudio.h
@@ -7360,6 +7360,7 @@ typedef struct
 
 MA_API ma_engine_node_config ma_engine_node_config_init(ma_engine* pEngine, ma_engine_node_type type, ma_uint32 flags);
 
+typedef void (*ma_dsp_proc)(void* pEngineNode, void* pFramesOut, const void* pFramesIn, ma_uint64 frameCount, ma_uint32 channels);
 
 /* Base node object for both ma_sound and ma_sound_group. */
 typedef struct
@@ -7394,6 +7395,7 @@ typedef struct
     /* Memory management. */
     ma_bool8 _ownsHeap;
     void* _pHeap;
+    ma_dsp_proc dspProc;
 } ma_engine_node;
 
 MA_API ma_result ma_engine_node_get_heap_size(const ma_engine_node_config* pConfig, size_t* pHeapSizeInBytes);


### PR DESCRIPTION
Adds the ability to assign a callback to an ma_engine_node object, which is called right after all processing on the ma_engine_node instance has been done. This allows the user to intercept the data and apply more effects on the sound without the need to set up custom nodes.