### PR TITLE
Add ma_decoder_get_encoding_format

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -9989,6 +9989,12 @@ Retrieves the decoder's output data format.
 MA_API ma_result ma_decoder_get_data_format(ma_decoder* pDecoder, ma_format* pFormat, ma_uint32* pChannels, ma_uint32* pSampleRate, ma_channel* pChannelMap, size_t channelMapCap);
 
 /*
+Retrieves the decoder's encoding data format.
+*/
+MA_API ma_result ma_decoder_get_encoding_format(ma_decoder* pDecoder, ma_encoding_format* pFormat);
+
+
+/*
 Retrieves the current position of the read cursor in PCM frames.
 */
 MA_API ma_result ma_decoder_get_cursor_in_pcm_frames(ma_decoder* pDecoder, ma_uint64* pCursor);
@@ -65326,6 +65332,45 @@ MA_API ma_result ma_decoder_get_data_format(ma_decoder* pDecoder, ma_format* pFo
         ma_data_converter_get_output_channel_map(&pDecoder->converter, pChannelMap, channelMapCap);
     }
 
+    return MA_SUCCESS;
+}
+
+MA_API ma_result ma_decoder_get_encoding_format(ma_decoder* pDecoder, ma_encoding_format* pFormat) 
+{
+    if (pDecoder == NULL) {
+        return MA_INVALID_ARGS;
+    }
+
+    if (pFormat == NULL) {
+        return MA_INVALID_ARGS;
+    }
+
+#ifdef MA_HAS_WAV
+    if(pDecoder->pBackendVTable == &g_ma_decoding_backend_vtable_wav){
+        *pFormat = ma_encoding_format_wav;
+        return MA_SUCCESS;
+    }
+#endif
+#ifdef MA_HAS_FLAC
+    if(pDecoder->pBackendVTable == &g_ma_decoding_backend_vtable_flac){
+        *pFormat = ma_encoding_format_flac;
+        return MA_SUCCESS;
+    }
+#endif
+#ifdef MA_HAS_MP3
+    if(pDecoder->pBackendVTable == &g_ma_decoding_backend_vtable_mp3){
+        *pFormat = ma_encoding_format_mp3;
+        return MA_SUCCESS;
+    }
+#endif
+#ifdef MA_HAS_VORBIS
+    if(pDecoder->pBackendVTable == &g_ma_decoding_backend_vtable_vorbis){
+        *pFormat = ma_encoding_format_vorbis;
+        return MA_SUCCESS;
+    }
+#endif
+
+    *pFormat = ma_encoding_format_unknown;
     return MA_SUCCESS;
 }
 


### PR DESCRIPTION
There are cases where we want to show a user the audio format, so being able to retrieve it after a decoder has initialized is helpful. I couldn't find a way to do this with the existing API so I added ma_decoder_get_encoding_format. Let me know if I missed something!

```
ma_decoder decoder;
ma_decoder_config config = ma_decoder_config_init(ma_format_f32, 0, 0);
if (ma_decoder_init_memory(..., ..., &config, &decoder) != MA_SUCCESS) {
    return;
}

// ... later

ma_encoding_format encodingFormat;
if (ma_decoder_get_encoding_format(&decoder, &encodingFormat) == MA_SUCCESS) {
    switch (encodingFormat)
    {
        case ma_encoding_format_mp3:
            printf("format is mp3\n");
            break;
        case ma_encoding_format_wav:
            printf("format is wav\n");
            break;
        case ma_encoding_format_vorbis:
            printf("format is ogg\n");
            break;
        case ma_encoding_format_flac:
            printf("format is flag\n");
            break;
        default:
            printf("format is unknown\n");
            break;
    }
}
```
