### PR TITLE
fixed typo in line 40491 (emscripten) ma_device__on_notification_unlo…

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -40488,7 +40488,7 @@ static ma_result ma_context_init__webaudio(ma_context* pContext, const ma_contex
                         device.state === window.miniaudio.device_state.started) {
 
                         device.webaudio.resume().then(() => {
-                                Module._ma_device__on_notification_unlocked(device.pDevice);
+                                Module.ma_device__on_notification_unlocked(device.pDevice);
                             },
                             (error) => {console.error("Failed to resume audiocontext", error);
                             });


### PR DESCRIPTION
I got this error when building to web via emscripten:
```
DungeonCrawlerJam_2024.js:1209 Uncaught (in promise) TypeError: Module._ma_device__on_notification_unlocked is not a function
```

And indeed in the source there's a underscore before the function name in line 40491, removing it fixed it for me!
