### PR TITLE
Support 'atexit'-based cleanup on Windows

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -16187,7 +16187,7 @@ static void ma_thread_wait__posix(ma_thread* pThread)
 static ma_result ma_mutex_init__posix(ma_mutex* pMutex)
 {
     int result;
-    
+
     if (pMutex == NULL) {
         return MA_INVALID_ARGS;
     }
@@ -42402,8 +42402,27 @@ MA_API ma_result ma_device_stop(ma_device* pDevice)
             /*
             We need to wait for the worker thread to become available for work before returning. Note that the worker thread will be
             the one who puts the device into the stopped state. Don't call ma_device__set_state() here.
+
+            When using miniaudio through a shared library on Windows, registering cleanup operations such as `ma_engine_uninit` via
+            `atexit` will result in a deadlock because all threads will be forcefully terminated without any thread-detach notification
+            by the Win32 runtime as part of `ExitProcess`.
+
+            To prevent the deadlock and support `atexit`-based cleanup (e.g. using miniaudio via C++ `static` objects), we only wait
+            for the stop event signal if the thread was not forcefully terminated.
+
+            Further reading: https://www.luke1410.de/blog/2017/02/the-trouble-of-separate-module-atexit-stacks/
             */
-            ma_event_wait(&pDevice->stopEvent);
+
+        #if defined(MA_WIN32)
+            const ma_bool32 shouldWait = WaitForSingleObject(pDevice->thread, 0) == WAIT_TIMEOUT;
+        #else
+            const ma_bool32 shouldWait = MA_TRUE;
+        #endif
+
+            if (shouldWait) {
+                ma_event_wait(&pDevice->stopEvent);
+            }
+
             result = MA_SUCCESS;
         }
 


### PR DESCRIPTION
Hello! 

We have started using `miniaudio` in [SFML 3.x](https://github.com/SFML/SFML) and so far our experience has been great.

As an attempt to simplify our audio resource management, I attempted to remove run-time based reference counting in lieu of a simpler manager object with a `static` lifetime -- an important first step towards adding support for multiple audio devices in our library (see https://github.com/SFML/SFML/pull/2974).

My changes unfortunately ended up causing problems on Windows, as any application using our audio module freezes on termination. After [some investigation by @binary1248](https://github.com/SFML/SFML/pull/2974#issuecomment-2118625698) and [some further tests by myself](https://github.com/SFML/SFML/pull/2974#issuecomment-2120618605) we realized that the problem is due to how Windows handles `atexit` and thread termination when building as a shared library.

Basically, as part of process termination procedure, the Win32 runtime will forcefully terminate any remaining thread without joining them nor sending a thread-detach notification. This means that anybody trying to cleanup `miniaudio` resources via `atexit` (which is exactly how C++'s `static` object destructors are invoked) will end up with a program hanging on `ma_event_wait(&pDevice->stopEvent)` inside `ma_engine_uninit`, because `pDevice->thread` was terminated and there was never a chance to signal the stop event.

A simple workaround for this issue is to check if the thread is still alive prior to waiting on `stopEvent`. I've done some research and found [this solution](https://stackoverflow.com/questions/301054/how-can-i-determine-if-a-win32-thread-has-terminated) that suggests it's sufficient to check `WaitForSingleObject(threadHandle, 0) == WAIT_TIMEOUT` to see if the thread is still alive.

Applying the changes to `miniaudio.h` and trying them out under our SFML test suite both as a static and as a shared library seems to resolve the issue and support our use case.

As an added benefit, any C or C++ developer using `atexit` for `miniaudio` cleanup will benefit from this change, and any other C++ developer using `static` lifetime for `miniaudio` cleanup will also do so.

Thanks!