### PR TITLE
Add a pDevice handle to the Web Audio device index when using worklets

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -39997,6 +39997,8 @@ static ma_result ma_device_uninit__webaudio(ma_device* pDevice)
                 device.streamNode.disconnect();
                 device.streamNode = undefined;
             }
+
+            device.pDevice = undefined;
         }, pDevice->webaudio.deviceIndex);
 
         emscripten_destroy_web_audio_node(pDevice->webaudio.audioWorklet);
@@ -40387,9 +40389,10 @@ static ma_result ma_device_init__webaudio(ma_device* pDevice, const ma_device_co
         pDevice->webaudio.deviceIndex = EM_ASM_INT({
             return window.miniaudio.track_device({
                 webaudio: emscriptenGetAudioObject($0),
-                state:    1 /* 1 = ma_device_state_stopped */
+                state:    1, /* 1 = ma_device_state_stopped */
+                pDevice: $1
             });
-        }, pDevice->webaudio.audioContext);
+        }, pDevice->webaudio.audioContext, pDevice);
 
         return MA_SUCCESS;
     }


### PR DESCRIPTION
This matches the handle added for script processor node devices in #771

Without this in place the context unlocking callbacks will throw errors on page interactions, because they assume a `pDevice` property is in place. I believe this was added in the script processor code paths in #771, but was missing on the worklet code paths.

The error:
```
RuntimeError: Aborted(Assertion failed: notification.pDevice != ((void*)0), at: miniaudio.h,18717,ma_device__on_notification)
```
