### PR TITLE
WebAudio: Fix a noise sound before device was started

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -40070,7 +40070,7 @@ static EM_BOOL ma_audio_worklet_process_callback__webaudio(int inputCount, const
     if (ma_device_get_state(pDevice) != ma_device_state_started) {
         /* Fill the output buffer with zero to avoid a noise sound */
         for (int i = 0; i < outputCount; i += 1) {
-            MA_ZERO_MEMORY(pOutputs[i].data, pOutputs[i].numberOfChannels * pOutputs[i].samplesPerChannel * sizeof(float));
+            MA_ZERO_MEMORY(pOutputs[i].data, pOutputs[i].numberOfChannels * /*pOutputs[i].samplesPerChannel*/frameCount * sizeof(float));
         }
         return EM_TRUE;
     }

--- a/miniaudio.h
+++ b/miniaudio.h
@@ -40069,8 +40069,8 @@ static EM_BOOL ma_audio_worklet_process_callback__webaudio(int inputCount, const
 
     if (ma_device_get_state(pDevice) != ma_device_state_started) {
         /* Fill the output buffer with zero to avoid a noise sound */
-        if (outputCount > 0) {
-            MA_ZERO_MEMORY(pOutputs[0].data, frameCount * pDevice->playback.internalChannels * sizeof(float));
+        for (int i = 0; i < outputCount; i += 1) {
+            MA_ZERO_MEMORY(pOutputs[i].data, pOutputs[i].numberOfChannels * pOutputs[i].samplesPerChannel * sizeof(float));
         }
         return EM_TRUE;
     }


### PR DESCRIPTION
Hello! In our project compiled with Emscripten and executed in a browser, we had a noise sound at startup. We found that it occurred after the device was init and before it was started. And if we don't start the device, we can hear the never-ending noise. This code fixes that: if the device is not started, the output buffer is filled with 0.