### PR TITLE
Android rerouting fix

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -38407,7 +38407,8 @@ error_disconnected:
                 result = ma_device_start__aaudio(pDevice);
                 if (result != MA_SUCCESS) {
                     /* We got disconnected! Retry a few times, until we find a connected device! */
-                    if (++retries <= 3) {
+                    retries += 1;
+                    if (retries <= 3) {
                         ma_log_postf(ma_device_get_log(pDevice), MA_LOG_LEVEL_INFO, "[AAudio] Failed to start stream after route change, retrying(%d)", retries);
                         goto error_disconnected;
                     }

--- a/miniaudio.h
+++ b/miniaudio.h
@@ -37956,7 +37956,9 @@ static ma_result ma_open_stream__aaudio(ma_device* pDevice, const ma_device_conf
 
 static ma_result ma_close_stream__aaudio(ma_context* pContext, ma_AAudioStream* pStream)
 {
-    MA_ASSERT(pStream != NULL);
+    if (pStream == NULL) {
+        return MA_INVALID_ARGS;
+    }
 
     return ma_result_from_aaudio(((MA_PFN_AAudioStream_close)pContext->aaudio.AAudioStream_close)(pStream));
 }
@@ -38092,16 +38094,12 @@ static ma_result ma_device_uninit__aaudio(ma_device* pDevice)
     /* When re-routing, streams may have been closed and never re-opened. Hence the extra checks below. */
 
     if (pDevice->type == ma_device_type_capture || pDevice->type == ma_device_type_duplex) {
-        if (pDevice->aaudio.pStreamCapture != NULL) {
-            ma_close_stream__aaudio(pDevice->pContext, (ma_AAudioStream*)pDevice->aaudio.pStreamCapture);
-            pDevice->aaudio.pStreamCapture = NULL;
-        }
+        ma_close_stream__aaudio(pDevice->pContext, (ma_AAudioStream*)pDevice->aaudio.pStreamCapture);
+        pDevice->aaudio.pStreamCapture = NULL;
     }
     if (pDevice->type == ma_device_type_playback || pDevice->type == ma_device_type_duplex) {
-        if (pDevice->aaudio.pStreamPlayback != NULL) {
-            ma_close_stream__aaudio(pDevice->pContext, (ma_AAudioStream*)pDevice->aaudio.pStreamPlayback);
-            pDevice->aaudio.pStreamPlayback = NULL;
-        }
+        ma_close_stream__aaudio(pDevice->pContext, (ma_AAudioStream*)pDevice->aaudio.pStreamPlayback);
+        pDevice->aaudio.pStreamPlayback = NULL;
     }
 
     return MA_SUCCESS;

--- a/miniaudio.h
+++ b/miniaudio.h
@@ -37953,6 +37953,8 @@ static ma_result ma_open_stream__aaudio(ma_device* pDevice, const ma_device_conf
 
 static ma_result ma_close_stream__aaudio(ma_context* pContext, ma_AAudioStream* pStream)
 {
+    MA_ASSERT(pStream != NULL);
+
     return ma_result_from_aaudio(((MA_PFN_AAudioStream_close)pContext->aaudio.AAudioStream_close)(pStream));
 }
 
@@ -38084,14 +38086,19 @@ static ma_result ma_device_uninit__aaudio(ma_device* pDevice)
 {
     MA_ASSERT(pDevice != NULL);
 
-    if (pDevice->type == ma_device_type_capture || pDevice->type == ma_device_type_duplex) {
-        ma_close_stream__aaudio(pDevice->pContext, (ma_AAudioStream*)pDevice->aaudio.pStreamCapture);
-        pDevice->aaudio.pStreamCapture = NULL;
-    }
+    /* When re-routing, streams may have been closed and never re-opened. Hence the extra checks below. */
 
+    if (pDevice->type == ma_device_type_capture || pDevice->type == ma_device_type_duplex) {
+        if (pDevice->aaudio.pStreamCapture != NULL) {
+            ma_close_stream__aaudio(pDevice->pContext, (ma_AAudioStream*)pDevice->aaudio.pStreamCapture);
+            pDevice->aaudio.pStreamCapture = NULL;
+        }
+    }
     if (pDevice->type == ma_device_type_playback || pDevice->type == ma_device_type_duplex) {
-        ma_close_stream__aaudio(pDevice->pContext, (ma_AAudioStream*)pDevice->aaudio.pStreamPlayback);
-        pDevice->aaudio.pStreamPlayback = NULL;
+        if (pDevice->aaudio.pStreamPlayback != NULL) {
+            ma_close_stream__aaudio(pDevice->pContext, (ma_AAudioStream*)pDevice->aaudio.pStreamPlayback);
+            pDevice->aaudio.pStreamPlayback = NULL;
+        }
     }
 
     return MA_SUCCESS;

--- a/miniaudio.h
+++ b/miniaudio.h
@@ -38369,6 +38369,7 @@ static ma_result ma_device_reinit__aaudio(ma_device* pDevice, ma_device_type dev
 
         result = ma_device_init__aaudio(pDevice, &deviceConfig, &descriptorPlayback, &descriptorCapture);
         if (result != MA_SUCCESS) {
+            ma_log_post(ma_device_get_log(pDevice), MA_LOG_LEVEL_ERROR, "[AAudio] Failed to create stream.");
             return result;
         }
 

--- a/miniaudio.h
+++ b/miniaudio.h
@@ -38369,13 +38369,16 @@ static ma_result ma_device_reinit__aaudio(ma_device* pDevice, ma_device_type dev
 
         result = ma_device_init__aaudio(pDevice, &deviceConfig, &descriptorPlayback, &descriptorCapture);
         if (result != MA_SUCCESS) {
-            ma_log_post(ma_device_get_log(pDevice), MA_LOG_LEVEL_ERROR, "[AAudio] Failed to create stream.");
+            ma_log_post(ma_device_get_log(pDevice), MA_LOG_LEVEL_WARNING, "[AAudio] Failed to create stream after route change.");
+            ma_device__set_state(pDevice, ma_device_state_stopped);
             return result;
         }
 
         result = ma_device_post_init(pDevice, deviceType, &descriptorPlayback, &descriptorCapture);
         if (result != MA_SUCCESS) {
+            ma_log_post(ma_device_get_log(pDevice), MA_LOG_LEVEL_WARNING, "[AAudio] Failed to initialize device after route change.");
             ma_device_uninit__aaudio(pDevice);
+            ma_device__set_state(pDevice, ma_device_state_stopped);
             return result;
         }
 


### PR DESCRIPTION
Fix for #913.

History
--------
In our game engine, [orx](https://github.com/orx/), we switched to `miniaudio` in late 2021. Ever since then, we observed a rare, intermittent problem on `Android` where audio would disappear (and never come back). Usually, it would happen when resuming a game after a few days. Then, in 2024, we found out that the issue is more likely to occur when taking a ride with the car 😆. It just happens that the car has a bluetooth audio device...

During these years, I have tried multiple devices, all running the latest `Android` version (API level `30` up to `35`). Just to name a few:
* Pixel 5
* Pixel 6
* Pixel 9 Pro
* Lenovo P12 Pro
* Samsung S7 (if I recall correctly)

What is the common denominator here? **Re-routing!**

Symptoms
--------
When re-routing, volume is usually lowered when returning back to the original device (this too is an important clue). Sometimes though, the audio is completely gone. In `logcat` we get a hint of what happened:
```logcat
restartIfDisabled(7071): releaseBuffer() track 0xb40000750d625420 disabled due to previous underrun, restarting
```
And you get this error for both `AAudio` and `OpenSL`. Thus, these two APIs overlap somehow. As it turns out, `AAudio` has two paths; `mmap` and `legacy`, where the former is more performant. When re-routing, our `AAudio` integration seems to choose the legacy path. This indicates that it fails to pick the `mmap` path for some reason. That's odd!

Now, if we _enforce_ the `mmap` path by calling `AAudio_setMMapPolicy(AAUDIO_POLICY_ALWAYS)`, re-routing **always** fails at this line:
```c
result = ma_device_init__aaudio(pDevice, &deviceConfig, &descriptorPlayback, &descriptorCapture);
```
Error is `AAUDIO_ERROR_OUT_OF_RANGE` due to the buffer size logic in [AudioStreamInternal.cpp(295)](https://android.googlesource.com/platform/frameworks/av/+/master/media/libaaudio/src/client/AudioStreamInternal.cpp#295).

Clearly, re-routing does not work for `mmap` enabled devices. Makes no sense!

The fix
-------
It turns out that there are fragments in the code that aim to handle this very issue.
```c
if (!pConfig->aaudio.enableCompatibilityWorkarounds || ma_android_sdk_version() > 30)
```

**Indeed, removing the workaround fixes the problem!** Re-routing now maintains the `mmap` path, avoiding the less stable `legacy` path. Also, when reading information about the default device via `ma_open_stream_basic__aaudio` we now set `AAUDIO_PERFORMANCE_MODE_LOW_LATENCY`, _allowing_ for the `mmap` path. This likely reduces the "path confusion" inside `AAudio`. Ideally, I would like to have the same logic as in `ma_create_and_configure_AAudioStreamBuilder__aaudio` but this is the best I can come up with when there is no `ma_device_config` to consider.

Final notes
--------
You might want to re-iterate the removal of `enableCompatibilityWorkarounds`. However, since I have struggled with this issue since 2021 I'm quite confident that the "compatibility workarounds" were added at a time when `AAudio` still had some growing pains. My take is that the workarounds are no longer needed.