### PR TITLE
Fix warnings for vars may be used uninitialized in this function

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -70025,10 +70025,10 @@ static void ma_resource_manager_data_stream_fill_page(ma_resource_manager_data_s
 
     /* The decoder needs to inherit the stream's looping and range state. */
     {
-        ma_uint64 rangeBeg;
-        ma_uint64 rangeEnd;
-        ma_uint64 loopPointBeg;
-        ma_uint64 loopPointEnd;
+        ma_uint64 rangeBeg = 0;
+        ma_uint64 rangeEnd = 0;
+        ma_uint64 loopPointBeg = 0;
+        ma_uint64 loopPointEnd = 0;
 
         ma_data_source_set_looping(&pDataStream->decoder, ma_resource_manager_data_stream_is_looping(pDataStream));
 


### PR DESCRIPTION
Hello, while cross-compiling miniaudio (dev branch) on Linux to Windows using `mingw`, there were some warnings for vars that _"may be used uninitialized in this function"_. By looking at `ma_resource_manager_data_stream_fill_page()` that likely won't be the case. However, just to fix/silence the warnings, I'm submitting this PR for consideration. Thank you.

<details>
<summary>Compiling log:</summary>
<br>

``` bash
In file included from main.c:122:
external/miniaudio-dev/miniaudio.h: In function ‘ma_resource_manager_data_stream_fill_page’:
external/miniaudio-dev/miniaudio.h:70036:9: warning: ‘rangeBeg’ may be used uninitialized in this function [-Wmaybe-uninitialized]
70036 |         ma_data_source_set_range_in_pcm_frames(&pDataStream->decoder, rangeBeg, rangeEnd);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
external/miniaudio-dev/miniaudio.h:70036:9: warning: ‘rangeEnd’ may be used uninitialized in this function [-Wmaybe-uninitialized]
external/miniaudio-dev/miniaudio.h:70039:9: warning: ‘loopPointEnd’ may be used uninitialized in this function [-Wmaybe-uninitialized]
70039 |         ma_data_source_set_loop_point_in_pcm_frames(&pDataStream->decoder, loopPointBeg, loopPointEnd);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
external/miniaudio-dev/miniaudio.h:70039:9: warning: ‘loopPointBeg’ may be used uninitialized in this function [-Wmaybe-uninitialized]
```
</details>