### PR TITLE
Add new API method for seeking audio streams using seconds; bugfix where one method returns success when NULL is parsed; typo corrected in a comment

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -57774,7 +57774,7 @@ MA_API ma_result ma_data_source_seek_seconds(ma_data_source* pDataSource, float 
     }
 
     /* We need PCM frames instead of seconds */
-    frameCount = secondCount * sampleRate;
+    frameCount = (ma_uint64)(secondCount * sampleRate);
 
     result = ma_data_source_seek_pcm_frames(pDataSource, frameCount, &framesSeeked);
 
@@ -57799,7 +57799,7 @@ MA_API ma_result ma_data_source_seek_to_second(ma_data_source* pDataSource, floa
     }
 
     /* We need PCM frames instead of seconds */
-    frameIndex = secondIndex * sampleRate;
+    frameIndex = (ma_uint64)(secondIndex * sampleRate);
 
     return ma_data_source_seek_to_pcm_frame(pDataSource, frameIndex);
 }
@@ -77418,7 +77418,7 @@ MA_API ma_result ma_sound_seek_to_second(ma_sound* pSound, float secondIndex)
     }
 
     /* We need PCM frames. We need to convert first */
-    frameIndex = secondIndex * sampleRate;
+    frameIndex = (ma_uint64)(secondIndex * sampleRate);
 
     return ma_sound_seek_to_pcm_frame(pSound, frameIndex);
 }

--- a/miniaudio.h
+++ b/miniaudio.h
@@ -57773,7 +57773,7 @@ MA_API ma_result ma_data_source_seek_seconds(ma_data_source* pDataSource, float 
         return result;
     }
 
-    result = ma_data_source_read_pcm_frames(pDataSource, NULL, frameCount, &framesSeeked);
+    result = ma_data_source_seek_pcm_frames(pDataSource, frameCount, &framesSeeked);
 
     /* VC6 doesn't support division between unsigned 64-bit integer and floating point number. Signed integer needed. This shouldn't affect anything in practice */
     *pSecondsSeeked = (ma_int64)framesSeeked / (float)sampleRate;
@@ -57782,18 +57782,12 @@ MA_API ma_result ma_data_source_seek_seconds(ma_data_source* pDataSource, float 
 
 MA_API ma_result ma_data_source_seek_to_second(ma_data_source* pDataSource, float secondIndex)
 {
-    /* Dev note: This definition is very similar to definition of ma_data_source_seek_to_pcm_frame() */
-    ma_data_source_base* pDataSourceBase = (ma_data_source_base*)pDataSource;
     ma_uint64 frameIndex;
     ma_uint32 sampleRate;
     ma_result result;
 
-    if (pDataSourceBase == NULL) {
+    if (pDataSource == NULL) {
         return MA_INVALID_ARGS;
-    }
-
-    if (pDataSourceBase->vtable->onSeek == NULL) {
-        return MA_NOT_IMPLEMENTED;
     }
 
     result = ma_data_source_get_data_format(pDataSource, NULL, NULL, &sampleRate, NULL, 0);
@@ -57804,13 +57798,7 @@ MA_API ma_result ma_data_source_seek_to_second(ma_data_source* pDataSource, floa
     /* We need PCM frames instead of seconds */
     frameIndex = secondIndex * sampleRate;
 
-    if (frameIndex > pDataSourceBase->rangeEndInFrames) {
-        return MA_INVALID_OPERATION;    /* Trying to seek too far forward. */
-    }
-
-    MA_ASSERT(pDataSourceBase->vtable != NULL);
-
-    return pDataSourceBase->vtable->onSeek(pDataSource, pDataSourceBase->rangeBegInFrames + frameIndex);
+    return ma_data_source_seek_to_pcm_frame(pDataSource, frameIndex);
 }
 
 MA_API ma_result ma_data_source_get_data_format(ma_data_source* pDataSource, ma_format* pFormat, ma_uint32* pChannels, ma_uint32* pSampleRate, ma_channel* pChannelMap, size_t channelMapCap)
@@ -77413,7 +77401,6 @@ MA_API ma_result ma_sound_seek_to_pcm_frame(ma_sound* pSound, ma_uint64 frameInd
 
 MA_API ma_result ma_sound_seek_to_second(ma_sound* pSound, float secondIndex)
 {
-    /* Dev note: this definition if very similar to `ma_sound_seek_to_pcm_frame`s definition */
     ma_uint64 frameIndex;
     ma_uint32 sampleRate;
     ma_result result;
@@ -77422,11 +77409,7 @@ MA_API ma_result ma_sound_seek_to_second(ma_sound* pSound, float secondIndex)
         return MA_INVALID_ARGS;
     }
 
-    if (pSound->pDataSource == NULL) {
-        return MA_INVALID_OPERATION;
-    }
-
-    result = ma_data_source_get_data_format(pSound->pDataSource, NULL, NULL, &sampleRate, NULL, 0);
+    result = ma_sound_get_data_format(pSound, NULL, NULL, &sampleRate, NULL, 0);
     if (result != MA_SUCCESS) {
         return result;
     }
@@ -77434,10 +77417,7 @@ MA_API ma_result ma_sound_seek_to_second(ma_sound* pSound, float secondIndex)
     /* We need PCM frames. We need to convert first */
     frameIndex = secondIndex * sampleRate;
 
-    /* We can't be seeking while reading at the same time. First exclusively change current cursor/position, then read afterwards */
-    ma_atomic_exchange_64(&pSound->seekTarget, frameIndex);
-
-    return MA_SUCCESS;
+    return ma_sound_seek_to_pcm_frame(pSound, frameIndex);
 }
 
 MA_API ma_result ma_sound_get_data_format(ma_sound* pSound, ma_format* pFormat, ma_uint32* pChannels, ma_uint32* pSampleRate, ma_channel* pChannelMap, size_t channelMapCap)

--- a/miniaudio.h
+++ b/miniaudio.h
@@ -5826,7 +5826,7 @@ MA_API ma_result ma_data_source_read_pcm_frames(ma_data_source* pDataSource, voi
 MA_API ma_result ma_data_source_seek_pcm_frames(ma_data_source* pDataSource, ma_uint64 frameCount, ma_uint64* pFramesSeeked); /* Can only seek forward. Equivalent to ma_data_source_read_pcm_frames(pDataSource, NULL, frameCount, &framesRead); */
 MA_API ma_result ma_data_source_seek_to_pcm_frame(ma_data_source* pDataSource, ma_uint64 frameIndex);
 MA_API ma_result ma_data_source_seek_seconds(ma_data_source* pDataSource, float secondCount, float* pSecondsSeeked); /* Can only seek forward. Abstraction to ma_data_source_seek_pcm_frames() */
-MA_API ma_result ma_data_source_seek_to_second(ma_data_source* pDataSource, float secondIndex); /* Abstraction to ma_data_source_seek_to_pcm_frame() */
+MA_API ma_result ma_data_source_seek_to_second(ma_data_source* pDataSource, float seekPointInSeconds); /* Abstraction to ma_data_source_seek_to_pcm_frame() */
 MA_API ma_result ma_data_source_get_data_format(ma_data_source* pDataSource, ma_format* pFormat, ma_uint32* pChannels, ma_uint32* pSampleRate, ma_channel* pChannelMap, size_t channelMapCap);
 MA_API ma_result ma_data_source_get_cursor_in_pcm_frames(ma_data_source* pDataSource, ma_uint64* pCursor);
 MA_API ma_result ma_data_source_get_length_in_pcm_frames(ma_data_source* pDataSource, ma_uint64* pLength);    /* Returns MA_NOT_IMPLEMENTED if the length is unknown or cannot be determined. Decoders can return this. */
@@ -11395,7 +11395,7 @@ MA_API void ma_sound_set_looping(ma_sound* pSound, ma_bool32 isLooping);
 MA_API ma_bool32 ma_sound_is_looping(const ma_sound* pSound);
 MA_API ma_bool32 ma_sound_at_end(const ma_sound* pSound);
 MA_API ma_result ma_sound_seek_to_pcm_frame(ma_sound* pSound, ma_uint64 frameIndex); /* Just a wrapper around ma_data_source_seek_to_pcm_frame(). */
-MA_API ma_result ma_sound_seek_to_second(ma_sound* pSound, float secondIndex); /* Abstraction to ma_sound_seek_to_pcm_frame() */
+MA_API ma_result ma_sound_seek_to_second(ma_sound* pSound, float seekPointInSeconds); /* Abstraction to ma_sound_seek_to_pcm_frame() */
 MA_API ma_result ma_sound_get_data_format(ma_sound* pSound, ma_format* pFormat, ma_uint32* pChannels, ma_uint32* pSampleRate, ma_channel* pChannelMap, size_t channelMapCap);
 MA_API ma_result ma_sound_get_cursor_in_pcm_frames(ma_sound* pSound, ma_uint64* pCursor);
 MA_API ma_result ma_sound_get_length_in_pcm_frames(ma_sound* pSound, ma_uint64* pLength);
@@ -57783,7 +57783,7 @@ MA_API ma_result ma_data_source_seek_seconds(ma_data_source* pDataSource, float 
     return result;
 }
 
-MA_API ma_result ma_data_source_seek_to_second(ma_data_source* pDataSource, float secondIndex)
+MA_API ma_result ma_data_source_seek_to_second(ma_data_source* pDataSource, float seekPointInSeconds)
 {
     ma_uint64 frameIndex;
     ma_uint32 sampleRate;
@@ -57799,7 +57799,7 @@ MA_API ma_result ma_data_source_seek_to_second(ma_data_source* pDataSource, floa
     }
 
     /* We need PCM frames instead of seconds */
-    frameIndex = (ma_uint64)(secondIndex * sampleRate);
+    frameIndex = (ma_uint64)(seekPointInSeconds * sampleRate);
 
     return ma_data_source_seek_to_pcm_frame(pDataSource, frameIndex);
 }
@@ -77402,7 +77402,7 @@ MA_API ma_result ma_sound_seek_to_pcm_frame(ma_sound* pSound, ma_uint64 frameInd
     return MA_SUCCESS;
 }
 
-MA_API ma_result ma_sound_seek_to_second(ma_sound* pSound, float secondIndex)
+MA_API ma_result ma_sound_seek_to_second(ma_sound* pSound, float seekPointInSeconds)
 {
     ma_uint64 frameIndex;
     ma_uint32 sampleRate;
@@ -77418,7 +77418,7 @@ MA_API ma_result ma_sound_seek_to_second(ma_sound* pSound, float secondIndex)
     }
 
     /* We need PCM frames. We need to convert first */
-    frameIndex = (ma_uint64)(secondIndex * sampleRate);
+    frameIndex = (ma_uint64)(seekPointInSeconds * sampleRate);
 
     return ma_sound_seek_to_pcm_frame(pSound, frameIndex);
 }

--- a/miniaudio.h
+++ b/miniaudio.h
@@ -57773,6 +57773,9 @@ MA_API ma_result ma_data_source_seek_seconds(ma_data_source* pDataSource, float 
         return result;
     }
 
+    /* We need PCM frames instead of seconds */
+    frameCount = secondCount * sampleRate;
+
     result = ma_data_source_seek_pcm_frames(pDataSource, frameCount, &framesSeeked);
 
     /* VC6 doesn't support division between unsigned 64-bit integer and floating point number. Signed integer needed. This shouldn't affect anything in practice */

--- a/miniaudio.h
+++ b/miniaudio.h
@@ -57741,7 +57741,7 @@ MA_API ma_result ma_data_source_seek_to_pcm_frame(ma_data_source* pDataSource, m
     ma_data_source_base* pDataSourceBase = (ma_data_source_base*)pDataSource;
 
     if (pDataSourceBase == NULL) {
-        return MA_SUCCESS;
+        return MA_INVALID_ARGS;
     }
 
     if (pDataSourceBase->vtable->onSeek == NULL) {
@@ -57749,7 +57749,7 @@ MA_API ma_result ma_data_source_seek_to_pcm_frame(ma_data_source* pDataSource, m
     }
 
     if (frameIndex > pDataSourceBase->rangeEndInFrames) {
-        return MA_INVALID_OPERATION;    /* Trying to seek to far forward. */
+        return MA_INVALID_OPERATION;    /* Trying to seek too far forward. */
     }
 
     MA_ASSERT(pDataSourceBase->vtable != NULL);


### PR DESCRIPTION
Since there is one API method called `ma_sound_seek_to_pcm_frame()` available to end-users, it would be nice to have similar API methods that use seconds instead of PCM frames (as there are other alternative methods having their PCM equivalents).
Three new methods are introduced:
- `ma_result ma_sound_seek_to_second(ma_sound*, float)` (matches `ma_sound_seek_to_pcm_frame(ma_sound*, ma_uint64)`),
- `ma_result ma_data_source_seek_to_second(ma_data_source*, float)` (matches `ma_data_source_seek_to_pcm_frame(ma_data_source*, ma_uint64`), and
- `ma_result ma_data_source_seek_seconds(ma_data_source*, float, float*)` (matches `ma_data_source_seek_pcm_frames(ma_data_source*, ma_uint64, ma_uint64*)`)

While reading definitions of those inspired functions, I noticed that there is (I suppose) a bug in `ma_result ma_data_source_seek_to_pcm_frame(ma_data_source *pDataSource, ma_uint64 frameIndex)` where this function returns `MA_SUCCESS` when `pDataSource` is `NULL`, while other similar functions return `MA_INVALID_ARGS`. It should not return successful operation on uninitialized data source `pDataSource`. That was a one line change. Another thing I've noticed was a typo in a comment inside the same function definition, so I quickly corrected that in the same commit where this bugfix is done.

To test new changes, I wrote a mini program (`main.c`):
```c
#include <stdio.h>
#include <stdlib.h>

#define MINIAUDIO_IMPLEMENTATION
#include "miniaudio.h"

int main() {
  ma_result result;
  ma_engine engine;
  ma_sound sound;
  ma_data_source *data_src;
  char shit;

  // Checking if pDataSource is passed properly to `ma_data_source_seek_to_pcm_frame()` method...
  result = ma_data_source_seek_to_pcm_frame(NULL, 441000); // 10s for sampleRate = 44'100
  printf("Bugfix check result: %d\n", result);

  result = ma_engine_init(NULL, &engine);
  if (result)
    return result;

  result = ma_sound_init_from_file(&engine, "HITC.mp3", 0, NULL, NULL, &sound);
  if (result)
    return result;

  // Testing method no. 1:
  printf("Song \"Heavy is the Crown\" is loaded :D\n");
  result = ma_sound_seek_to_second(&sound, 6.0);
  if (result)
    printf("bruh\n");

  ma_sound_start(&sound);
  printf("Press enter to continue...\n");
  scanf("%c", &shit);
  while (getchar() != '\n');

  ma_sound_stop(&sound);

  data_src = sound.pDataSource;

  // Testing method no. 2:
  ma_data_source_seek_to_second(data_src, 42.5f);
  ma_sound_start(&sound);
  printf("Press enter to continue 2...\n");
  scanf("%c", &shit);
  while (getchar() != '\n');

  // Testing method no. 3
  float seekd;
  ma_uint64 fseekd;
  ma_sound_stop(&sound);
  // ma_data_source_seek_seconds(data_src, 10.0f, &seekd);
  ma_data_source_seek_pcm_frames(data_src, 441000, &fseekd);
  /* Unable to test `ma_data_source_seek_seconds()`
     Reason: There's a NULL dereference inside of
             Miniaudio implementation.
             `ma_data_source_seek_pcm_frames()` is
             also affected
  */

  printf("Press enter to exit...\n");
  scanf("%c", &shit);

  ma_sound_stop(&sound);
  ma_sound_uninit(&sound);
  ma_engine_uninit(&engine);

  printf("secs seekd: %f\n", seekd);
  
  return 0;
}
```
And compiled with `gcc main.c -o main -lm -ldl -pthread -g`

Two new methods `ma_sound_seek_to_second()` and `ma_data_source_seek_to_second()` work as expected, and `ma_data_source_seek_to_pcm_frame()` returns error properly...

...but the last new method `ma_data_source_seek_seconds()` leads to segmentation fault. Though it was something in my implementation, so I tried out quickly with its pair `ma_data_source_seek_pcm_frames()`, and it also segfaults. Those two functions lead to segmentation fault because... TLDR: `NULL` value is passed to second argument `void *pFramesOut` of `ma_data_source_read_pcm_frames()` function, where further a `NULL` value was dereferenced.

On the eye, `ma_data_source_seek_seconds()` seems fine. For this segfault problem, I can create an issue or make separate PR, but I'll discuss with you first on what's appropriate action.