### PR TITLE
AAudio stream mutex

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -38662,7 +38662,7 @@ error_disconnected:
         result = ma_device_post_init(pDevice, deviceType, &descriptorPlayback, &descriptorCapture);
         if (result != MA_SUCCESS) {
             ma_log_post(ma_device_get_log(pDevice), MA_LOG_LEVEL_WARNING, "[AAudio] Failed to initialize device after route change.");
-            ma_device_uninit__aaudio(pDevice);
+            ma_close_streams__aaudio(pDevice);
             return result;
         }
 


### PR DESCRIPTION
`AAudio` streams may be closed from UI thread or reroute thread. Introduced mutex to handle a race condition where a double-free would be possible.

Relevant changes:
* Using mutex to close opened streams.
* Re-routing closes the streams using function `ma_close_streams__aaudio()`, ignoring the `deviceType` argument. I think this is more accurate. @mackron Please confirm!

This **should** fix the final issue of #920. Need a few days to confirm. 