### PR TITLE
Fix miniaudio_libvorbis.h compilation as c++

### DIFF
--- a/extras/miniaudio_libvorbis.h
+++ b/extras/miniaudio_libvorbis.h
@@ -326,7 +326,7 @@ MA_API ma_result ma_libvorbis_read_pcm_frames(ma_libvorbis* pVorbis, void* pFram
                     }
                 }
             } else {
-                libvorbisResult = ov_read(&pVorbis->vf, ma_offset_pcm_frames_ptr(pFramesOut, totalFramesRead, format, channels), framesToRead * ma_get_bytes_per_frame(format, channels), 0, 2, 1, NULL);
+                libvorbisResult = ov_read(&pVorbis->vf, (char*)ma_offset_pcm_frames_ptr(pFramesOut, totalFramesRead, format, channels), framesToRead * ma_get_bytes_per_frame(format, channels), 0, 2, 1, NULL);
                 if (libvorbisResult < 0) {
                     result = MA_ERROR;  /* Error while decoding. */
                     break;


### PR DESCRIPTION
Currently attempting to include `miniaudio_libvorbis.h` in a c++ translation unit will not compile due to an implicit cast of void* to char*