### PR TITLE
Address leaked pResourceManagerDataSource when invalid input causes sound init to fail

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -76801,6 +76801,7 @@ MA_API ma_result ma_sound_init_from_file_internal(ma_engine* pEngine, const ma_s
 
         result = ma_resource_manager_data_source_init_ex(pEngine->pResourceManager, &resourceManagerDataSourceConfig, pSound->pResourceManagerDataSource);
         if (result != MA_SUCCESS) {
+            ma_free(pSound->pResourceManagerDataSource, &pEngine->allocationCallbacks);
             goto done;
         }
 


### PR DESCRIPTION
Hi,

Nothing major here; just stopping by to address this memory leak which occurs when a sound fails to initialize due to the file being invalid.

Thank you for this wonderful library!
