### PR TITLE
CMake: support install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,32 @@ option(MINIAUDIO_USE_STDINT                    "Use <stdint.h> for sized types" 
 option(MINIAUDIO_DEBUG_OUTPUT                  "Enable stdout debug output"          OFF)
 
 
+set(LIBS_TO_INSTALL)
+
+# This assumes that our static library has exactly one .c file and 1 .h file, both named ${prefix.c} and ${prefix.h} respectively
+# prefix is optional and defaults to name
+macro(add_miniaudio_library name relpath)
+    set(prefix ${name})
+    set (extra_args ${ARGN})
+
+    list(LENGTH extra_args extra_count)
+    if (${extra_count} GREATER 0)
+        list(GET extra_args 0 prefix)
+    endif ()
+
+    add_library(${name} STATIC
+        ${relpath}/${prefix}.c
+        ${relpath}/${prefix}.h
+    )
+    # Without this, changes made to LIBS_TO_INSTALL disappear when we return
+    list(APPEND LIBS_TO_INSTALL ${name})
+    set(LIBS_TO_INSTALL ${LIBS_TO_INSTALL} PARENT_SCOPE)
+
+    install(FILES ${relpath}/${prefix}.h
+        DESTINATION include/miniaudio/${relpath})
+        target_include_directories(${name} PUBLIC ${dir})
+endmacro()
+
 # Construct compiler options.
 set(COMPILE_OPTIONS)
 
@@ -452,12 +478,8 @@ endif()
 
 
 # Static Libraries
-add_library(miniaudio STATIC
-    miniaudio.c
-    miniaudio.h
-)
+add_miniaudio_library(miniaudio ".")
 
-target_include_directories(miniaudio PUBLIC  ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_options    (miniaudio PRIVATE ${COMPILE_OPTIONS})
 target_compile_definitions(miniaudio PRIVATE ${COMPILE_DEFINES})
 
@@ -472,10 +494,7 @@ if(HAS_LIBVORBIS)
 endif()
 
 if(HAS_LIBVORBIS)
-    add_library(miniaudio_libvorbis STATIC
-        extras/decoders/libvorbis/miniaudio_libvorbis.c
-        extras/decoders/libvorbis/miniaudio_libvorbis.h
-    )
+    add_miniaudio_library(miniaudio_libvorbis extras/decoders/libvorbis)
 
     target_compile_options    (miniaudio_libvorbis PRIVATE ${COMPILE_OPTIONS})
     target_compile_definitions(miniaudio_libvorbis PRIVATE ${COMPILE_DEFINES})
@@ -494,10 +513,7 @@ if(HAS_LIBOPUS)
 endif()
 
 if(HAS_LIBOPUS)
-    add_library(miniaudio_libopus STATIC
-        extras/decoders/libopus/miniaudio_libopus.c
-        extras/decoders/libopus/miniaudio_libopus.h
-    )
+    add_miniaudio_library(miniaudio_libopus extras/decoders/libopus)
 
     target_compile_options    (miniaudio_libopus PRIVATE ${COMPILE_OPTIONS})
     target_compile_definitions(miniaudio_libopus PRIVATE ${COMPILE_DEFINES})
@@ -507,12 +523,8 @@ endif()
 
 if (NOT MINIAUDIO_NO_EXTRA_NODES)
     function(add_extra_node name)
-        add_library(miniaudio_${name}_node STATIC
-            extras/nodes/ma_${name}_node/ma_${name}_node.c
-            extras/nodes/ma_${name}_node/ma_${name}_node.h
-        )
+        add_miniaudio_library(miniaudio_${name}_node extras/nodes/ma_${name}_node ma_${name}_node)
 
-        target_include_directories(miniaudio_${name}_node PUBLIC  ${CMAKE_CURRENT_SOURCE_DIR}/extras/nodes/ma_${name}_node)
         target_compile_options    (miniaudio_${name}_node PRIVATE ${COMPILE_OPTIONS})
         target_compile_definitions(miniaudio_${name}_node PRIVATE ${COMPILE_DEFINES})
 
@@ -645,3 +657,15 @@ if (MINIAUDIO_BUILD_EXAMPLES)
     add_miniaudio_example(miniaudio_simple_playback simple_playback.c)
     add_miniaudio_example(miniaudio_simple_spatialization simple_spatialization.c)
 endif()
+
+include(GNUInstallDirs)
+
+
+
+install(
+    TARGETS ${LIBS_TO_INSTALL}
+    LIBRARY DESTINATION  "${CMAKE_INSTALL_LIBDIR}"
+    ARCHIVE DESTINATION  "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION  "${CMAKE_INSTALL_BINDIR}"
+    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 
 <p align="center">
     <a href="https://discord.gg/9vpqbjU"><img src="https://img.shields.io/discord/712952679415939085?label=discord&logo=discord&style=flat-square" alt="discord"></a>
-    <a href="https://fosstodon.org/@mackron"><img src="https://img.shields.io/mastodon/follow/109293691403797709?color=blue&domain=https%3A%2F%2Ffosstodon.org&label=mastodon&logo=mastodon&style=flat-square" alt="mastodon"></a>
 </p>
 
 <p align="center">

--- a/examples/custom_decoder_engine.c
+++ b/examples/custom_decoder_engine.c
@@ -72,5 +72,8 @@ int main(int argc, char** argv)
     printf("Press Enter to quit...");
     getchar();
 
+    ma_engine_uninit(&engine);
+    ma_resource_manager_uninit(&resourceManager);
+
     return 0;
 }

--- a/external/fs/fs.c
+++ b/external/fs/fs.c
@@ -4951,7 +4951,7 @@ static fs_result fs_file_seek_stdio(fs_file* pFile, fs_int64 offset, fs_seek_ori
     #else
         /* No _fseeki64() so restrict to 31 bits. */
         if (origin > 0x7FFFFFFF) {
-            return ERANGE;
+            return FS_OUT_OF_RANGE;
         }
 
         result = fseek(pFileStdio->pFile, (int)offset, whence);

--- a/miniaudio.h
+++ b/miniaudio.h
@@ -92875,7 +92875,7 @@ static ma_bool32 ma_dr_mp3_init_internal(ma_dr_mp3* pMP3, ma_dr_mp3_read_proc on
                 }
                 pMP3->streamLength = (ma_uint64)streamLen;
                 if (pMP3->memory.pData != NULL) {
-                    pMP3->memory.dataSize = pMP3->streamLength;
+                    pMP3->memory.dataSize = (size_t)pMP3->streamLength;
                 }
             } else {
                 if (!onSeek(pUserData, 0, ma_dr_mp3_seek_origin_start)) {

--- a/miniaudio.h
+++ b/miniaudio.h
@@ -37850,8 +37850,7 @@ static void ma_stream_error_callback__aaudio(ma_AAudioStream* pStream, void* pUs
     
         if (pStream == pDevice->aaudio.pStreamCapture) {
             job.data.device.aaudio.reroute.deviceType = ma_device_type_capture;
-        }
-        else {
+        } else {
             job.data.device.aaudio.reroute.deviceType = ma_device_type_playback;
         }
     
@@ -38193,8 +38192,9 @@ static ma_result ma_device_uninit__aaudio(ma_device* pDevice)
 {
     MA_ASSERT(pDevice != NULL);
 
-    /* Note: Closing the streams may cause a timeout error, which would then trigger rerouting in our error callback.
-       We must not schedule a reroute when device is getting destroyed.
+    /*
+    Note: Closing the streams may cause a timeout error, which would then trigger rerouting in our error callback.
+    We must not schedule a reroute when device is getting destroyed.
     */
     ma_atomic_bool32_set(&pDevice->aaudio.isTearingDown, MA_TRUE);
 


### PR DESCRIPTION
All Miniaudio static libraries now install their headers such that they can
still use relative paths, but external code can #include "miniaudio/miniaudio.h"

Also adds a CMake macro to simplify adding static libraries

