### PR TITLE
Resource manager custom resampler

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -10492,6 +10492,7 @@ typedef struct
     ma_decoding_backend_vtable** ppCustomDecodingBackendVTables;
     ma_uint32 customDecodingBackendCount;
     void* pCustomDecodingBackendUserData;
+    ma_resampler_config resampling;
 } ma_resource_manager_config;
 
 MA_API ma_resource_manager_config ma_resource_manager_config_init(void);
@@ -68312,6 +68313,7 @@ MA_API ma_resource_manager_config ma_resource_manager_config_init(void)
         config.jobThreadCount = 0;
     }
     #endif
+    config.resampling     = ma_resampler_config_init(ma_format_unknown, 0, 0, 0, ma_resample_algorithm_linear); /* Format/channels/rate doesn't matter here. */
 
     return config;
 }
@@ -68555,6 +68557,7 @@ static ma_decoder_config ma_resource_manager__init_decoder_config(ma_resource_ma
     config.ppCustomBackendVTables = pResourceManager->config.ppCustomDecodingBackendVTables;
     config.customBackendCount     = pResourceManager->config.customDecodingBackendCount;
     config.pCustomBackendUserData = pResourceManager->config.pCustomDecodingBackendUserData;
+    config.resampling = pResourceManager->config.resampling;
 
     return config;
 }


### PR DESCRIPTION
Hi David,

Here's one more small contribution for your consideration.

This adds support for a custom resampler to the resource manager. Not for pitch shifting / doppler as discussed in https://github.com/mackron/miniaudio/issues/965, but rather for initial decoding of sounds.

Please let me know if there's anything I need to change or improve. Just like with the previous PR, please be advised that I may need a little patience / support with regards to stylistic concerns due to a disability.

Kind regards,

Jordan.
