### PR TITLE
Fix seek origin conversion in ma_mp3_dr_callback__seek

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -64357,9 +64357,12 @@ static ma_bool32 ma_mp3_dr_callback__seek(void* pUserData, int offset, ma_dr_mp3
 
     MA_ASSERT(pMP3 != NULL);
 
-    maSeekOrigin = ma_seek_origin_start;
-    if (origin == ma_dr_mp3_seek_origin_current) {
-        maSeekOrigin =  ma_seek_origin_current;
+    if (origin == ma_dr_mp3_seek_origin_start) {
+        maSeekOrigin =  ma_seek_origin_start;
+    } else if (origin == ma_dr_mp3_seek_origin_end) {
+        maSeekOrigin = ma_seek_origin_end;
+    } else {
+        maSeekOrigin = ma_seek_origin_current;
     }
 
     result = pMP3->onSeek(pMP3->pReadSeekTellUserData, offset, maSeekOrigin);


### PR DESCRIPTION
The `ma_mp3_dr_callback__seek` function is converting only `ma_dr_mp3_seek_origin origin` to `ma_seek_origin_start` or `ma_seek_origin_current`. There is a condition missing for `ma_seek_origin_end`. 

This is fixing #991.