### PR TITLE
[dev-0.12] Fix seek origin enums on extras

### DIFF
--- a/extras/decoders/libopus/miniaudio_libopus.c
+++ b/extras/decoders/libopus/miniaudio_libopus.c
@@ -70,11 +70,11 @@ static int ma_libopus_of_callback__seek(void* pUserData, ogg_int64_t offset, int
     ma_seek_origin origin;
 
     if (whence == SEEK_SET) {
-        origin = ma_seek_origin_start;
+        origin = MA_SEEK_SET;
     } else if (whence == SEEK_END) {
-        origin = ma_seek_origin_end;
+        origin = MA_SEEK_END;
     } else {
-        origin = ma_seek_origin_current;
+        origin = MA_SEEK_CUR;
     }
 
     result = pOpus->onSeek(pOpus->pReadSeekTellUserData, offset, origin);
@@ -138,7 +138,7 @@ MA_API ma_result ma_libopus_init(ma_read_proc onRead, ma_seek_proc onSeek, ma_te
     ma_result result;
 
     (void)pAllocationCallbacks; /* Can't seem to find a way to configure memory allocations in libopus. */
-    
+
     result = ma_libopus_init_internal(pConfig, pOpus);
     if (result != MA_SUCCESS) {
         return result;

--- a/extras/decoders/libvorbis/miniaudio_libvorbis.c
+++ b/extras/decoders/libvorbis/miniaudio_libvorbis.c
@@ -80,11 +80,11 @@ static int ma_libvorbis_vf_callback__seek(void* pUserData, ogg_int64_t offset, i
     ma_seek_origin origin;
 
     if (whence == SEEK_SET) {
-        origin = ma_seek_origin_start;
+        origin = MA_SEEK_SET;
     } else if (whence == SEEK_END) {
-        origin = ma_seek_origin_end;
+        origin = MA_SEEK_END;
     } else {
-        origin = ma_seek_origin_current;
+        origin = MA_SEEK_CUR;
     }
 
     result = pVorbis->onSeek(pVorbis->pReadSeekTellUserData, offset, origin);
@@ -100,7 +100,7 @@ static long ma_libvorbis_vf_callback__tell(void* pUserData)
     ma_libvorbis* pVorbis = (ma_libvorbis*)pUserData;
     ma_result result;
     ma_int64 cursor;
-    
+
     result = pVorbis->onTell(pVorbis->pReadSeekTellUserData, &cursor);
     if (result != MA_SUCCESS) {
         return -1;
@@ -164,7 +164,7 @@ MA_API ma_result ma_libvorbis_init(ma_read_proc onRead, ma_seek_proc onSeek, ma_
     if (onRead == NULL || onSeek == NULL) {
         return MA_INVALID_ARGS; /* onRead and onSeek are mandatory. */
     }
-    
+
     result = ma_libvorbis_init_internal(pConfig, pAllocationCallbacks, pVorbis);
     if (result != MA_SUCCESS) {
         return result;

--- a/extras/miniaudio_libopus.h
+++ b/extras/miniaudio_libopus.h
@@ -112,11 +112,11 @@ static int ma_libopus_of_callback__seek(void* pUserData, ogg_int64_t offset, int
     ma_seek_origin origin;
 
     if (whence == SEEK_SET) {
-        origin = ma_seek_origin_start;
+        origin = MA_SEEK_SET;
     } else if (whence == SEEK_END) {
-        origin = ma_seek_origin_end;
+        origin = MA_SEEK_END;
     } else {
-        origin = ma_seek_origin_current;
+        origin = MA_SEEK_CUR;
     }
 
     result = pOpus->onSeek(pOpus->pReadSeekTellUserData, offset, origin);
@@ -180,7 +180,7 @@ MA_API ma_result ma_libopus_init(ma_read_proc onRead, ma_seek_proc onSeek, ma_te
     ma_result result;
 
     (void)pAllocationCallbacks; /* Can't seem to find a way to configure memory allocations in libopus. */
-    
+
     result = ma_libopus_init_internal(pConfig, pOpus);
     if (result != MA_SUCCESS) {
         return result;

--- a/extras/miniaudio_libvorbis.h
+++ b/extras/miniaudio_libvorbis.h
@@ -122,11 +122,11 @@ static int ma_libvorbis_vf_callback__seek(void* pUserData, ogg_int64_t offset, i
     ma_seek_origin origin;
 
     if (whence == SEEK_SET) {
-        origin = ma_seek_origin_start;
+        origin = MA_SEEK_SET;
     } else if (whence == SEEK_END) {
-        origin = ma_seek_origin_end;
+        origin = MA_SEEK_END;
     } else {
-        origin = ma_seek_origin_current;
+        origin = MA_SEEK_CUR;
     }
 
     result = pVorbis->onSeek(pVorbis->pReadSeekTellUserData, offset, origin);
@@ -142,7 +142,7 @@ static long ma_libvorbis_vf_callback__tell(void* pUserData)
     ma_libvorbis* pVorbis = (ma_libvorbis*)pUserData;
     ma_result result;
     ma_int64 cursor;
-    
+
     result = pVorbis->onTell(pVorbis->pReadSeekTellUserData, &cursor);
     if (result != MA_SUCCESS) {
         return -1;
@@ -186,7 +186,7 @@ MA_API ma_result ma_libvorbis_init(ma_read_proc onRead, ma_seek_proc onSeek, ma_
     ma_result result;
 
     (void)pAllocationCallbacks; /* Can't seem to find a way to configure memory allocations in libvorbis. */
-    
+
     result = ma_libvorbis_init_internal(pConfig, pVorbis);
     if (result != MA_SUCCESS) {
         return result;


### PR DESCRIPTION
Hello, the recent API change (57423c6) that renamed the `ma_seek_origin` enums ended up missing the extras files. So trying to compile the `dev-0.12` branch causes some `undeclared (first use in this function)` errors (log below). This PR just finishes those missing renames on the `dev-0.12` branch.

<details><summary>Error log</summary>

```
[...]
[ 56%] Linking C static library libvorbis.a
[ 56%] Built target vorbis
[ 58%] Building C object external/vorbis/lib/CMakeFiles/vorbisfile.dir/vorbisfile.c.o
[ 60%] Linking C static library libvorbisfile.a
[ 60%] Built target vorbisfile
[ 63%] Building C object CMakeFiles/miniaudio_libvorbis.dir/extras/decoders/libvorbis/miniaudio_libvorbis.c.o
/home/user/miniaudio/extras/decoders/libvorbis/miniaudio_libvorbis.c: In function ‘ma_libvorbis_vf_callback__seek’:
/home/user/miniaudio/extras/decoders/libvorbis/miniaudio_libvorbis.c:83:18: error: ‘ma_seek_origin_start’ undeclared (first use in this function); did you mean ‘ma_seek_origin’?
   83 |         origin = ma_seek_origin_start;
      |                  ^~~~~~~~~~~~~~~~~~~~
      |                  ma_seek_origin
/home/user/miniaudio/extras/decoders/libvorbis/miniaudio_libvorbis.c:83:18: note: each undeclared identifier is reported only once for each function it appears in
/home/user/miniaudio/extras/decoders/libvorbis/miniaudio_libvorbis.c:85:18: error: ‘ma_seek_origin_end’ undeclared (first use in this function); did you mean ‘ma_seek_origin’?
   85 |         origin = ma_seek_origin_end;
      |                  ^~~~~~~~~~~~~~~~~~
      |                  ma_seek_origin
/home/user/miniaudio/extras/decoders/libvorbis/miniaudio_libvorbis.c:87:18: error: ‘ma_seek_origin_current’ undeclared (first use in this function); did you mean ‘ma_seek_origin’?
   87 |         origin = ma_seek_origin_current;
      |                  ^~~~~~~~~~~~~~~~~~~~~~
      |                  ma_seek_origin
gmake[2]: *** [CMakeFiles/miniaudio_libvorbis.dir/build.make:76: CMakeFiles/miniaudio_libvorbis.dir/extras/decoders/libvorbis/miniaudio_libvorbis.c.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:223: CMakeFiles/miniaudio_libvorbis.dir/all] Error 2
gmake: *** [Makefile:156: all] Error 2
```
</details>