### PR TITLE
Fix warning: function declaration without a prototype

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -38326,7 +38326,7 @@ OSS Backend
 
 #define MA_OSS_DEFAULT_DEVICE_NAME  "/dev/dsp"
 
-static int ma_open_temp_device__oss()
+static int ma_open_temp_device__oss(void)
 {
     /* The OSS sample code uses "/dev/mixer" as the device for getting system properties so I'm going to do the same. */
     int fd = open("/dev/mixer", O_RDONLY, 0);


### PR DESCRIPTION
Harmless warning on FreeBSD 14.2,
https://cirrus-ci.com/task/4700955851096064?logs=build#L44

```
../subprojects/miniaudio-0.11.22/miniaudio.h:36997:36: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
 36997 | static int ma_open_temp_device__oss()
       |                                    ^
       |                                     void
```

