### PR TITLE
Fix CMake for OpenBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,11 @@ option(MINIAUDIO_NO_RUNTIME_LINKING            "Disable runtime linking"        
 option(MINIAUDIO_USE_STDINT                    "Use <stdint.h> for sized types"      OFF)
 option(MINIAUDIO_DEBUG_OUTPUT                  "Enable stdout debug output"          OFF)
 
+# /usr/local/include is not included in the base includes by default
+# add it to prevent header not found errors
+if (CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+    include_directories(${OPENBSD_LOCALBASE}/include)
+endif()
 
 # Construct compiler options.
 set(COMPILE_OPTIONS)


### PR DESCRIPTION
`/usr/local/include` isn't included in the cmake base includes on OpenBSD.
That causes a compilation error due to some headers not found, like `vorbis/vorbis.h`.
I've updated `CMakeLists.txt` to include `/usr/local/include`on OpenBSD.

Here's the compilation error I get before applying this fix (`libvorbisfile` is installed):
~~~
[ 14%] Linking C static library libminiaudio.a
[ 14%] Built target miniaudio
[ 21%] Building C object CMakeFiles/miniaudio_libvorbis.dir/extras/decoders/libvorbis/miniaudio_libvorbis.c.o
/home/yuce/temp/miniaudio/extras/decoders/libvorbis/miniaudio_libvorbis.c:10:10: fatal error: 'vorbis/vorbisfile.h' file not found
#include <vorbis/vorbisfile.h>
         ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
*** Error 1 in . (CMakeFiles/miniaudio_libvorbis.dir/build.make:79 'CMakeFiles/miniaudio_libvorbis.dir/extras/decoders/libvorbis/miniaudio_libvorbis.c.o')
*** Error 2 in . (CMakeFiles/Makefile2:137 'CMakeFiles/miniaudio_libvorbis.dir/all': /usr/bin/make -s -f CMakeFiles/miniaudio_libvorbis.dir/...)
*** Error 2 in /home/yuce/temp/miniaudio/build (Makefile:91 'all': /usr/bin/make -s -f CMakeFiles/Makefile2 all)
~~~