### PR TITLE
Fix access to miniaudio in ma_context_uninit__webaudio.

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -42237,8 +42237,8 @@ static ma_result ma_context_uninit__webaudio(ma_context* pContext)
     /* Remove the global miniaudio object from window if there are no more references to it. */
     EM_ASM({
         if (typeof(window.miniaudio) !== 'undefined') {
-            miniaudio.unlock_event_types.map(function(event_type) {
-                document.removeEventListener(event_type, miniaudio.unlock, true);
+            window.miniaudio.unlock_event_types.map(function(event_type) {
+                document.removeEventListener(event_type, window.miniaudio.unlock, true);
             });
 
             window.miniaudio.referenceCount -= 1;


### PR DESCRIPTION
The compilation with emscripten failed when passing `--closure 1` as parameter because the `miniaudio` variable is not defined in `ma_context_uninit__webaudio`. It should be `window.miniaudio`.