### PR TITLE
Add device enumeration for Android

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -40041,7 +40041,9 @@ static ma_aaudio_performance_mode_t ma_to_performance_mode__aaudio(ma_aaudio_per
 
 typedef struct ma_context_state_aaudio
 {
+#ifndef MA_ANDROID_NO_JNI
     JavaVM* pVM;
+#endif
     ma_handle hAAudio; /* libaaudio.so */
     MA_PFN_AAudio_createStreamBuilder                    AAudio_createStreamBuilder;
     MA_PFN_AAudioStreamBuilder_delete                    AAudioStreamBuilder_delete;
@@ -40213,7 +40215,9 @@ static ma_result ma_context_init__aaudio(ma_context* pContext, const void* pCont
     }
     #endif
 
+#ifndef MA_ANDROID_NO_JNI
     pContextStateAAudio->pVM = (JavaVM *)pContextConfigAAudio->pVM;
+#endif
 
     /* We need a job thread so we can deal with rerouting. */
     {


### PR DESCRIPTION
This is a draft proposal for retrieving and enumerating audio devices on Android using the JNI interface. It's not ready for merging yet, but I'd like to start a discussion about this approach. 

What are your thoughts on using the JNI interface to get the device list?

Known issues that need addressing:
1. Default Device Selection Problem: Currently, the default device is determined by its index position in the list, since there's no direct way to get the preferred audio route. The only alternative would be to:
    - Create an AudioTrack to play silent audio
    - Call [AudioRouting.getPreferredDevice()](https://developer.android.com/reference/android/media/AudioRouting#getPreferredDevice()) to get the preferred route
    - Release the AudioTrack
  
    However, I don't think this approach is ideal. An alternative would be creating a priority system based on device type (e.g., speaker > bluetooth > built-in).

2. Missing device type information: The current implementation doesn't expose the device type, which is crucial for disambiguation. Many devices show multiple entries with the same name (typically the phone's model name) for different audio outputs like built-in speaker and built-in earphone, making them impossible to distinguish without type information.



