### PR TITLE
Fix `ma_device_stop` for asynchronous backends

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -44049,11 +44049,10 @@ static ma_thread_result MA_THREADCALL ma_audio_thread(void* pData)
             }
         } else if (pOp->type == MA_DEVICE_OP_STOP) {
             /*
-            The comments above said that we should never get a stop event here, but *technically* we can if `ma_device_stop()`
-            is called at the same time as the backend itself terminated from its own loop. Exceptionally unlikely, but possible.
-            In this case we're just going to signal the op. We do not want to call into the backend's stop callback.
+            This can happen for asynchronous backends that manage their own loop. When the device is running and
+            ma_device_stop() is called, the STOP operation will be received here. We need to properly stop the device.
             */
-            ma_device_op_completion_event_signal(pOp->pCompletionEvent, MA_SUCCESS);
+            ma_device_op_do_stop(pDevice, pOp->pCompletionEvent);
         } else {
             MA_ASSERT(!"Unexpected device op.");
         }


### PR DESCRIPTION
In the audio thread of asynchronous backends, the following condition keeps the for loop running while it waits for a new operation in the queue.

```c
if (ma_context_is_backend_asynchronous(ma_device_get_context(pDevice))) {
    continue;   /* <-- This just makes the audio thread wait for a new operation to arrive, like an uninit or stop. */
}
```

You should then stop the backend when a MA_DEVICE_OP_STOP operation is queued rather than only triggering a signal.

```c
for (;;) {
    // You will be waiting again for a new operation to be queued.
    result = ma_device_op_queue_next(&pDevice->opQueue, MA_BLOCKING_MODE_BLOCKING, &pOp); 
    if (result != MA_SUCCESS) {
        break;
    }

    if (pOp->type == MA_DEVICE_OP_UNINIT) {
        ...
    } else if (pOp->type == MA_DEVICE_OP_START) {
        ...
    } else if (pOp->type == MA_DEVICE_OP_STOP) {
        // <-- You should handle the stop operation here and not only send a signal.
        ma_device_op_do_stop(pDevice, pOp->pCompletionEvent);
    }
}
```

I  might be missing something about how the backend interaction works, but I don't see where the backend is being stopped elsewhere