### PR TITLE
Do not set POSIX thread scheduler policy on systems reporting that they do not support it

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -17616,7 +17616,7 @@ static ma_result ma_thread_create__posix(ma_thread* pThread, ma_thread_priority 
             int priorityStep = (priorityMax - priorityMin) / 7;  /* 7 = number of priorities supported by miniaudio. */
 
             struct sched_param sched;
-            if (pthread_attr_getschedparam(&attr, &sched) == 0) {
+            if (priorityMin != -1 && priorityMax != -1 && pthread_attr_getschedparam(&attr, &sched) == 0) {
                 if (priority == ma_thread_priority_idle) {
                     sched.sched_priority = priorityMin;
                 } else if (priority == ma_thread_priority_realtime) {


### PR DESCRIPTION
Hello,

Creating this PR to fix https://github.com/mackron/miniaudio/issues/1053.

On few systems where we create threads using ma_thread_create__posix (e.g. Android), sched_get_priority_min/max return -1, indicating that this feature is not supported. This causes the thread creation to fail, and to get no audio, due to passing -1 that gives "invalid argument" when calling pthread_create.

This PR is simply about not calling pthread_attr_setschedparam/pthread_attr_setinheritsched and therefore not setting thread scheduler policy for those systems.

Tested successfully under an Android Redmi Pad 2 tablet that was affected.

Feel free to ask for anything,

Thank you,
Louis