### PR TITLE
cmake: add public include directories for extra decoders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -539,6 +539,7 @@ if(HAS_LIBVORBIS)
     target_compile_options    (miniaudio_libvorbis PRIVATE ${COMPILE_OPTIONS})
     target_compile_definitions(miniaudio_libvorbis PRIVATE ${COMPILE_DEFINES})
     target_link_libraries     (miniaudio_libvorbis PRIVATE libvorbis_interface)
+    target_include_directories(miniaudio_libvorbis PUBLIC  extras/decoders/libvorbis/)
 endif()
 
 
@@ -567,6 +568,7 @@ if(HAS_LIBOPUS)
     target_compile_options    (miniaudio_libopus PRIVATE ${COMPILE_OPTIONS})
     target_compile_definitions(miniaudio_libopus PRIVATE ${COMPILE_DEFINES})
     target_link_libraries     (miniaudio_libopus PRIVATE libopus_interface)
+    target_include_directories(miniaudio_libopus PUBLIC  extras/decoders/libopus/)
 endif()
 
 


### PR DESCRIPTION
It seems that when linking, for example, `miniaudio_libvorbis`, it doesn't add the necessary include directories for use in the project. This is because the include directories were not being added to the target at all.

Here, I fix that by adding them with PUBLIC scope.
