### PR TITLE
Use `MA_API` instead of `extern` for extras.

### DIFF
--- a/extras/backends/pipewire/miniaudio_pipewire.c
+++ b/extras/backends/pipewire/miniaudio_pipewire.c
@@ -1701,13 +1701,13 @@ static ma_device_backend_vtable ma_gDeviceBackendVTable_PipeWire =
     NULL    /* onDeviceWakeup */
 };
 
-ma_device_backend_vtable* ma_device_backend_pipewire = &ma_gDeviceBackendVTable_PipeWire;
+MA_API ma_device_backend_vtable* ma_device_backend_pipewire = &ma_gDeviceBackendVTable_PipeWire;
 
 #if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)))
     #pragma GCC diagnostic pop
 #endif
 #else
-ma_device_backend_vtable* ma_device_backend_pipewire = NULL;
+MA_API ma_device_backend_vtable* ma_device_backend_pipewire = NULL;
 #endif  /* MA_HAS_PIPEWIRE */
 
 MA_API ma_context_config_pipewire ma_context_config_pipewire_init(void)

--- a/extras/backends/pipewire/miniaudio_pipewire.h
+++ b/extras/backends/pipewire/miniaudio_pipewire.h
@@ -27,7 +27,7 @@ support it.
 extern "C" {
 #endif
 
-extern ma_device_backend_vtable* ma_device_backend_pipewire;
+MA_API ma_device_backend_vtable* ma_device_backend_pipewire;
 
 
 typedef struct

--- a/extras/backends/sdl/backend_sdl.c
+++ b/extras/backends/sdl/backend_sdl.c
@@ -636,9 +636,9 @@ static ma_device_backend_vtable ma_gDeviceBackendVTable_SDL =
     NULL    /* onDeviceWakeup */
 };
 
-ma_device_backend_vtable* ma_device_backend_sdl = &ma_gDeviceBackendVTable_SDL;
+MA_API ma_device_backend_vtable* ma_device_backend_sdl = &ma_gDeviceBackendVTable_SDL;
 #else
-ma_device_backend_vtable* ma_device_backend_sdl = NULL;
+MA_API ma_device_backend_vtable* ma_device_backend_sdl = NULL;
 #endif  /* MA_HAS_SDL */
 
 

--- a/extras/backends/sdl/backend_sdl.h
+++ b/extras/backends/sdl/backend_sdl.h
@@ -10,7 +10,7 @@ and device configs.
 extern "C" {
 #endif
 
-extern ma_device_backend_vtable* ma_device_backend_sdl;
+MA_API ma_device_backend_vtable* ma_device_backend_sdl;
 
 
 typedef struct

--- a/extras/decoders/libopus/miniaudio_libopus.c
+++ b/extras/decoders/libopus/miniaudio_libopus.c
@@ -550,9 +550,9 @@ static ma_decoding_backend_vtable ma_gDecodingBackendVTable_libopus =
     ma_decoding_backend_uninit__libopus,
     ma_decoding_backend_get_encoding_format__libopus
 };
-ma_decoding_backend_vtable* ma_decoding_backend_libopus = &ma_gDecodingBackendVTable_libopus;
+MA_API ma_decoding_backend_vtable* ma_decoding_backend_libopus = &ma_gDecodingBackendVTable_libopus;
 #else
-ma_decoding_backend_vtable* ma_decoding_backend_libopus = NULL;
+MA_API ma_decoding_backend_vtable* ma_decoding_backend_libopus = NULL;
 #endif
 
 #endif  /* miniaudio_libopus_c */

--- a/extras/decoders/libopus/miniaudio_libopus.h
+++ b/extras/decoders/libopus/miniaudio_libopus.h
@@ -34,7 +34,7 @@ MA_API ma_result ma_libopus_get_cursor_in_pcm_frames(ma_libopus* pOpus, ma_uint6
 MA_API ma_result ma_libopus_get_length_in_pcm_frames(ma_libopus* pOpus, ma_uint64* pLength);
 
 /* Decoding backend vtable. This is what you'll plug into ma_decoder_config.pBackendVTables. No user data required. */
-extern ma_decoding_backend_vtable* ma_decoding_backend_libopus;
+MA_API ma_decoding_backend_vtable* ma_decoding_backend_libopus;
 
 #ifdef __cplusplus
 }

--- a/extras/decoders/libvorbis/miniaudio_libvorbis.c
+++ b/extras/decoders/libvorbis/miniaudio_libvorbis.c
@@ -604,9 +604,9 @@ static ma_decoding_backend_vtable ma_gDecodingBackendVTable_libvorbis =
     ma_decoding_backend_uninit__libvorbis,
     ma_decoding_backend_get_encoding_format__libvorbis
 };
-ma_decoding_backend_vtable* ma_decoding_backend_libvorbis = &ma_gDecodingBackendVTable_libvorbis;
+MA_API ma_decoding_backend_vtable* ma_decoding_backend_libvorbis = &ma_gDecodingBackendVTable_libvorbis;
 #else
-ma_decoding_backend_vtable* ma_decoding_backend_libvorbis = NULL;
+MA_API ma_decoding_backend_vtable* ma_decoding_backend_libvorbis = NULL;
 #endif
 
 #endif /* miniaudio_libvorbis_c */

--- a/extras/decoders/libvorbis/miniaudio_libvorbis.h
+++ b/extras/decoders/libvorbis/miniaudio_libvorbis.h
@@ -34,7 +34,7 @@ MA_API ma_result ma_libvorbis_get_cursor_in_pcm_frames(ma_libvorbis* pVorbis, ma
 MA_API ma_result ma_libvorbis_get_length_in_pcm_frames(ma_libvorbis* pVorbis, ma_uint64* pLength);
 
 /* Decoding backend vtable. This is what you'll plug into ma_decoder_config.pBackendVTables. No user data required. */
-extern ma_decoding_backend_vtable* ma_decoding_backend_libvorbis;
+MA_API ma_decoding_backend_vtable* ma_decoding_backend_libvorbis;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR changes `extern` to `MA_API` so DLL linkage works correctly if used in extras.