### PR TITLE
Fix windows error from wide string literal macro being wrongly recognized as an "int" internally in the compiler if import above is included

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-(This fork was done specifically for me to pull request to the parent repository)
-
 <h1 align="center">
     <a href="https://miniaud.io"><img src="https://miniaud.io/img/miniaudio_wide.png" alt="miniaudio" width="1280"></a>
     <br>


### PR DESCRIPTION
What I have included
```cpp
//#include "include/ma_thing.h" this line is for including it my personal rhythm game project. don't worry avbout this include.

#if _WIN32
#define WIN32_LEAN_AND_MEAN
#include <windows.h>
#endif

// Then include stb_vorbis as C code
#ifdef __cplusplus
extern "C" {
#endif

#define STB_VORBIS_IMPLEMENTATION
#include "extras/stb_vorbis.c"

#ifdef __cplusplus
}
#endif

#define MINIAUDIO_IMPLEMENTATION
#include "miniaudio.h"
```

So I somehow got stb_vorbis working in an exotic way, at the cost of errors, so I was determined to find out where it came from, and it turns out: the MA_VIRTUAL_AUDIO_DEVICE_PROCESS_LOOPBACK macro defines the wide string literal as an int on my MSVC 2022 compiler, so I had changed it to just be local, as a `const wchar_t*`, as only one line had used it.

Oh and btw `master` and `dev` have the same miniaudio.h which is a coincidence considering I forked from master instead, but I don't really think it matters imo. Same code.