### PR TITLE
WebAudio: Try to fix a startup noise

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -41779,7 +41779,7 @@ static EM_BOOL ma_audio_worklet_process_callback__webaudio(int inputCount, const
                     pOutputs[0].data[frameCount*iChannel + iFrame] = pDevice->webaudio.pIntermediaryBuffer[iFrame*pDevice->playback.internalChannels + iChannel];
                 }
             }
-            /* Ensure all output buffers are filled with zero */
+            /* Ensure all remaining output buffers (index >= 1) are filled with zero */
             for (int i = 1; i < outputCount; i += 1) {
                 MA_ZERO_MEMORY(pOutputs[i].data, pOutputs[i].numberOfChannels * frameCount * sizeof(float));
             }


### PR DESCRIPTION
Hello ! I'm making another PR about a noise issue during start-up. The first one (https://github.com/mackron/miniaudio/pull/908) fixed the problem at the time, but it would still occur, although very rarely, randomly, and always at startup.

So I tried to see where in the code this could be happening, to make sure I always had a full empty output buffer. But unfortunately, it's impossible to know if my fix is correct, or if the problem isn't coming from emscripten or web audio instead.
We noticed the issue on Safari and Chrome, and our project works with Electron... I think there could be a thousand reasons why something is going wrong.