### PR TITLE
Fix integer overflow on 32-bit system

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -20083,7 +20083,7 @@ Timing
             struct timespec newTime;
             clock_gettime(MA_CLOCK_ID, &newTime);
 
-            pTimer->counter = (newTime.tv_sec * 1000000000) + newTime.tv_nsec;
+            pTimer->counter = ((ma_int64) newTime.tv_sec * 1000000000) + newTime.tv_nsec;
         }
 
         static MA_INLINE double ma_timer_get_time_in_seconds(ma_timer* pTimer)
@@ -20094,7 +20094,7 @@ Timing
             struct timespec newTime;
             clock_gettime(MA_CLOCK_ID, &newTime);
 
-            newTimeCounter = (newTime.tv_sec * 1000000000) + newTime.tv_nsec;
+            newTimeCounter = ((ma_uint64) newTime.tv_sec * 1000000000) + newTime.tv_nsec;
             oldTimeCounter = pTimer->counter;
 
             return (newTimeCounter - oldTimeCounter) / 1000000000.0;
@@ -20105,7 +20105,7 @@ Timing
             struct timeval newTime;
             gettimeofday(&newTime, NULL);
 
-            pTimer->counter = (newTime.tv_sec * 1000000) + newTime.tv_usec;
+            pTimer->counter = ((ma_int64) newTime.tv_sec * 1000000) + newTime.tv_usec;
         }
 
         static MA_INLINE double ma_timer_get_time_in_seconds(ma_timer* pTimer)
@@ -20116,7 +20116,7 @@ Timing
             struct timeval newTime;
             gettimeofday(&newTime, NULL);
 
-            newTimeCounter = (newTime.tv_sec * 1000000) + newTime.tv_usec;
+            newTimeCounter = ((ma_uint64) newTime.tv_sec * 1000000) + newTime.tv_usec;
             oldTimeCounter = pTimer->counter;
 
             return (newTimeCounter - oldTimeCounter) / 1000000.0;


### PR DESCRIPTION
`struct timespec` and `struct timeval`'s `tv_sec` is `long` which is `int32_t` on 32-bit system so it needs to be casted to `ma_(u)int64` before converting to micro or nanoseconds.

Minimum example:
```c
#include "../miniaudio.c"

int main(void) {
  ma_engine engine;
  ma_result result = ma_engine_init(NULL, &engine);
  if (result != MA_SUCCESS) return EXIT_FAILURE;
  ma_engine_uninit(&engine);
  return EXIT_SUCCESS;
}
```

```console
# gcc repro.c -ldl -lm -lpthread -Wall -Wextra -Wpedantic -fsanitize=undefined -std=c11 && ./a.out
../miniaudio.h:20108:47: runtime error: signed integer overflow: 1767997689 * 1000000 cannot be represented in type 'long int'
../miniaudio.h:20119:46: runtime error: signed integer overflow: 1767997689 * 1000000 cannot be represented in type 'long int'
../miniaudio.h:20119:46: runtime error: signed integer overflow: 1767997689 * 1000000 cannot be represented in type 'long int'
../miniaudio.h:20108:47: runtime error: signed integer overflow: 1767997689 * 1000000 cannot be represented in type 'long int'
# gcc repro.c -ldl -lm -lpthread -Wall -Wextra -Wpedantic -fsanitize=undefined && ./a.out
../miniaudio.h:20086:48: runtime error: signed integer overflow: 18017 * 1000000000 cannot be represented in type 'long int'
../miniaudio.h:20097:46: runtime error: signed integer overflow: 18017 * 1000000000 cannot be represented in type 'long int'
../miniaudio.h:20097:46: runtime error: signed integer overflow: 18017 * 1000000000 cannot be represented in type 'long int'
../miniaudio.h:20086:48: runtime error: signed integer overflow: 18017 * 1000000000 cannot be represented in type 'long int'
```