### PR TITLE
Free pa_context if connecting to PulseAudio fails.

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -31238,6 +31238,7 @@ static ma_result ma_init_pa_mainloop_and_pa_context__pulse(ma_context* pContext,
     result = ma_result_from_pulse(((ma_pa_context_connect_proc)pContext->pulse.pa_context_connect)((ma_pa_context*)pPulseContext, pServerName, (tryAutoSpawn) ? MA_PA_CONTEXT_NOFLAGS : MA_PA_CONTEXT_NOAUTOSPAWN, NULL));
     if (result != MA_SUCCESS) {
         ma_log_postf(ma_context_get_log(pContext), MA_LOG_LEVEL_ERROR, "[PulseAudio] Failed to connect PulseAudio context.");
+        ((ma_pa_context_unref_proc)pContext->pulse.pa_context_unref)((ma_pa_context*)(pPulseContext));
         ((ma_pa_mainloop_free_proc)pContext->pulse.pa_mainloop_free)((ma_pa_mainloop*)(pMainLoop));
         return result;
     }
@@ -31246,6 +31247,7 @@ static ma_result ma_init_pa_mainloop_and_pa_context__pulse(ma_context* pContext,
     result = ma_wait_for_pa_context_to_connect__pulse(pContext, pMainLoop, pPulseContext);
     if (result != MA_SUCCESS) {
         ma_log_postf(ma_context_get_log(pContext), MA_LOG_LEVEL_ERROR, "[PulseAudio] Waiting for connection failed.");
+        ((ma_pa_context_unref_proc)pContext->pulse.pa_context_unref)((ma_pa_context*)(pPulseContext));
         ((ma_pa_mainloop_free_proc)pContext->pulse.pa_mainloop_free)((ma_pa_mainloop*)(pMainLoop));
         return result;
     }


### PR DESCRIPTION
## Description

This is a potential fix for a file descriptor leak I have encountered on Linux devices with audio services disabled.

This PR adds two calls to `pa_context_unref` when connecting in `ma_init_pa_mainloop_and_pa_context__pulse` fails. The first call fixes the leak.

The second call after `ma_wait_for_pa_context_to_connect__pulse` seems to be missing also but I did not know how to get into this state to verify it.

Also I could not find any information in the PulseAudio docs when you need to call `pa_context_unref`. Neither `pa_context_new()` nor `pa_context_new_with_proplist()` specify whether the caller needs to free the context. But it seems to fix the leak.

Documentation I looked at: https://www.freedesktop.org/software/pulseaudio/doxygen/context_8h.html#a2784c754947a97f02c78b73d7b1c2d5f

## Minimal Reproducible Example

The following minimal reproducible example leaks file descriptors:

Disable audio services (on my Arch based system):

```bash
systemctl --user stop pipewire.socket pipewire-pulse.socket pipewire pipewire-pulse wireplumber
```

```c
#include <dirent.h>
#include <stdio.h>

#include "miniaudio.h"

int count_open_fds(void) {
    int count = 0;
    DIR *dir = opendir("/proc/self/fd");
    if (!dir) return -1;

    while (readdir(dir)) {
        count++;
    }
    closedir(dir);

    // Subtract "." and ".."
    return count - 2;
}

int main() {
    while (1) {
        ma_context context;
        ma_result result = ma_context_init(NULL, 0, NULL, &context);
        if (result == MA_SUCCESS) {
            ma_context_uninit(&context);
        }

        printf("Open FDs: %d\n", count_open_fds());
    }

    return 0;
}
```

Compile:

```bash
gcc miniaudio-repro.c ../miniaudio/miniaudio.c -I ../miniaudio -lm -lpthread
```

Partial Output:

```
...
Open FDs: 1020
Open FDs: 1021
Open FDs: 1022
Failed to create secure directory (/run/user/1000/pulse): Too many open files
socket(): Too many open files
Open FDs: 1023
shared memfd open() failed: Too many open files
Failed to create secure directory (/run/user/1000/pulse): Too many open files
socket(): Too many open files
...
```