### PR TITLE
make get_length_in_pcm_frames for libvorbis return length

### DIFF
--- a/extras/miniaudio_libvorbis.h
+++ b/extras/miniaudio_libvorbis.h
@@ -501,8 +501,7 @@ MA_API ma_result ma_libvorbis_get_length_in_pcm_frames(ma_libvorbis* pVorbis, ma
 
     #if !defined(MA_NO_LIBVORBIS)
     {
-        /* I don't know how to reliably retrieve the length in frames using libvorbis, so returning 0 for now. */
-        *pLength = 0;
+        *pLength = ov_pcm_total(&pVorbis->vf, -1);
 
         return MA_SUCCESS;
     }


### PR DESCRIPTION
Ok, so the reason I did the earlier PR was because we have a bug in kew where ogg files are skipped on the debian package, which uses an external miniaudio lib instead of the vendored one that has my changes. Of course none of the fixes in the previous PR relate to that. But I now debugged it and found the culprit. It's in miniaudio_libvorbis.h. We talked about this awhile ago, about returning length of the ogg files. I implemented the changes we discussed. It seems to work well, and people are using it, but of course I don't have your expertise or anything.