### PR TITLE
Make ma_android_sdk_version static

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -12169,7 +12169,7 @@ static MA_INLINE void ma_restore_denormals(unsigned int prevState)
 #ifdef MA_ANDROID
 #include <sys/system_properties.h>
 
-int ma_android_sdk_version()
+static int ma_android_sdk_version(void)
 {
     char sdkVersion[PROP_VALUE_MAX + 1] = {0, };
     if (__system_property_get("ro.build.version.sdk", sdkVersion)) {


### PR DESCRIPTION
Fails to build on Android NDK with `-Wmissing-prototypes -Werror`:

```
error: no previous prototype for function 'ma_android_sdk_version'
```

The function is only used within the implementation block, so `static` matches every other helper there (`ma_has_sse2`, `ma_has_neon`, …). No behavioral change.

Found via ggml-org/llama.cpp#21647.