### PR TITLE
Fix ma_stbvorbis_init in dev-0.12

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -74931,7 +74931,7 @@ MA_API ma_result ma_stbvorbis_init(ma_read_proc onRead, ma_seek_proc onSeek, ma_
     pVorbis->onSeek = onSeek;
     pVorbis->onTell = onTell;
     pVorbis->pReadSeekTellUserData = pReadSeekTellUserData;
-    ma_allocation_callbacks_init_copy(&pVorbis->allocationCallbacks, pAllocationCallbacks);
+    pVorbis->allocationCallbacks = ma_allocation_callbacks_init_copy(pAllocationCallbacks);
 
     #if !defined(MA_NO_VORBIS)
     {


### PR DESCRIPTION
I needed to use miniaudio 0.12 due to targetting the PSVita and noticed it wasn't compiling due to this.