### PR TITLE
Fix MP3 gapless cursor and length reporting

### DIFF
--- a/extras/miniaudio_split/miniaudio.c
+++ b/extras/miniaudio_split/miniaudio.c
@@ -53609,7 +53609,11 @@ MA_API ma_result ma_mp3_get_cursor_in_pcm_frames(ma_mp3* pMP3, ma_uint64* pCurso
 
     #if !defined(MA_NO_MP3)
     {
-        *pCursor = pMP3->dr.currentPCMFrame;
+        if (pMP3->dr.currentPCMFrame > pMP3->dr.delayInPCMFrames) {
+            *pCursor = pMP3->dr.currentPCMFrame - pMP3->dr.delayInPCMFrames;
+        } else {
+            *pCursor = 0;
+        }
 
         return MA_SUCCESS;
     }
@@ -83945,15 +83949,27 @@ MA_API ma_uint64 ma_dr_mp3_get_pcm_frame_count(ma_dr_mp3* pMP3)
         if (totalPCMFrameCount >= pMP3->delayInPCMFrames) {
             totalPCMFrameCount -= pMP3->delayInPCMFrames;
         } else {
+            totalPCMFrameCount = 0;
         }
         if (totalPCMFrameCount >= pMP3->paddingInPCMFrames) {
             totalPCMFrameCount -= pMP3->paddingInPCMFrames;
         } else {
+            totalPCMFrameCount = 0;
         }
         return totalPCMFrameCount;
     } else {
         if (!ma_dr_mp3_get_mp3_and_pcm_frame_count(pMP3, NULL, &totalPCMFrameCount)) {
             return 0;
+        }
+        if (totalPCMFrameCount >= pMP3->delayInPCMFrames) {
+            totalPCMFrameCount -= pMP3->delayInPCMFrames;
+        } else {
+            totalPCMFrameCount = 0;
+        }
+        if (totalPCMFrameCount >= pMP3->paddingInPCMFrames) {
+            totalPCMFrameCount -= pMP3->paddingInPCMFrames;
+        } else {
+            totalPCMFrameCount = 0;
         }
         return totalPCMFrameCount;
     }

--- a/miniaudio.h
+++ b/miniaudio.h
@@ -65149,7 +65149,11 @@ MA_API ma_result ma_mp3_get_cursor_in_pcm_frames(ma_mp3* pMP3, ma_uint64* pCurso
 
     #if !defined(MA_NO_MP3)
     {
-        *pCursor = pMP3->dr.currentPCMFrame;
+        if (pMP3->dr.currentPCMFrame > pMP3->dr.delayInPCMFrames) {
+            *pCursor = pMP3->dr.currentPCMFrame - pMP3->dr.delayInPCMFrames;
+        } else {
+            *pCursor = 0;
+        }
 
         return MA_SUCCESS;
     }
@@ -95485,15 +95489,27 @@ MA_API ma_uint64 ma_dr_mp3_get_pcm_frame_count(ma_dr_mp3* pMP3)
         if (totalPCMFrameCount >= pMP3->delayInPCMFrames) {
             totalPCMFrameCount -= pMP3->delayInPCMFrames;
         } else {
+            totalPCMFrameCount = 0;
         }
         if (totalPCMFrameCount >= pMP3->paddingInPCMFrames) {
             totalPCMFrameCount -= pMP3->paddingInPCMFrames;
         } else {
+            totalPCMFrameCount = 0;
         }
         return totalPCMFrameCount;
     } else {
         if (!ma_dr_mp3_get_mp3_and_pcm_frame_count(pMP3, NULL, &totalPCMFrameCount)) {
             return 0;
+        }
+        if (totalPCMFrameCount >= pMP3->delayInPCMFrames) {
+            totalPCMFrameCount -= pMP3->delayInPCMFrames;
+        } else {
+            totalPCMFrameCount = 0;
+        }
+        if (totalPCMFrameCount >= pMP3->paddingInPCMFrames) {
+            totalPCMFrameCount -= pMP3->paddingInPCMFrames;
+        } else {
+            totalPCMFrameCount = 0;
         }
         return totalPCMFrameCount;
     }


### PR DESCRIPTION
I am not sure if I did changes correctly since I am not mature enough in audio, so, please, check if this vibecoded commit is correct.

I am doing rhythm game, and I noticed large statistical mismatch in my hits timing distribution, something like 70+ ms delay. Turns out, only mp3 playback affected, everything else is like 25 ms input latency, which is my input latency from keypress sound to sound according to Audacity. Then I have learned about mp3 encoding and decoding and turns out there may be delays caused by: 1152 (Xing frame) + 576 (encoder delay) + 529 (decoder delay) = 2257 frames, divided by sample rate = 44100, and I get 51 ms, which should be adjusted by the library. So, 51+25=76 ms total, matches my statistics. Though I am not sure if encoder delay have anything to do with this commit, because the osu beatmap already contains some odd offsets... Oh, I guess this commit is fine.

TLDR Instead of doing this in my code:
```zig
if (self.is_mp3) {
    current_time -= @as(f64, @floatFromInt(1152 + 576 + 529)) / @as(f64, @floatFromInt(self.sample_rate)); // 2257 = 1152 (Xing frame) + 576 (encoder delay) + 529 (decoder delay)
}
```
I decoded to vibecode solution in miniaudio.

Thank you for your library. I use it via https://github.com/zig-gamedev/zaudio, so if this gets accepted, I will downstream this.