### PR TITLE
Fix heap-buffer-overflow (OOB Read) in Xing/Info header parsing

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -94910,8 +94910,10 @@ static ma_bool32 ma_dr_mp3_init_internal(ma_dr_mp3* pMP3, ma_dr_mp3_read_proc on
                 const ma_uint8* pTagDataBeg;
                 pTagDataBeg = pFirstFrameData + MA_DR_MP3_HDR_SIZE + (bs.pos/8);
                 pTagData    = pTagDataBeg;
-                isXing = (pTagData[0] == 'X' && pTagData[1] == 'i' && pTagData[2] == 'n' && pTagData[3] == 'g');
-                isInfo = (pTagData[0] == 'I' && pTagData[1] == 'n' && pTagData[2] == 'f' && pTagData[3] == 'o');
+                if ((size_t)(pTagDataBeg - pFirstFrameData) + 8 <= (size_t)firstFrameInfo.frame_bytes) {
+                    isXing = (pTagData[0] == 'X' && pTagData[1] == 'i' && pTagData[2] == 'n' && pTagData[3] == 'g');
+                    isInfo = (pTagData[0] == 'I' && pTagData[1] == 'n' && pTagData[2] == 'f' && pTagData[3] == 'o');
+                }
                 if (isXing || isInfo) {
                     ma_uint32 bytes = 0;
                     ma_uint32 flags = pTagData[7];


### PR DESCRIPTION
### Description
This PR fixes a Heap Buffer Overflow (OOB Read) vulnerability in the MP3 decoder initialization phase (`ma_dr_mp3_init_internal`).

When parsing the Xing/Info metadata header, the current implementation attempts to read up to 35 bytes without verifying if the provided data buffer is large enough. If a crafted MP3 file smaller than 35 bytes is provided, it results in an Out-of-Bounds Read, which can lead to a crash (DoS) in applications utilizing miniaudio to decode untrusted user audio files.

I have added a simple bounds check before the metadata parsing logic to ensure the buffer has sufficient data.

### Vulnerability Details & ASan Report
- **Vulnerability Type:** Heap-based Buffer Overflow (OOB Read / CWE-125)
- **Impact:** Denial of Service (Application Crash) / Memory Disclosure

```text
[asan_report.txt](https://github.com/user-attachments/files/28378834/asan_report.txt)



Reproducer (PoC)
The crash can be reproduced using the following 35-byte minimal crafted MP3 payload:

C
// Payload generated by libFuzzer
unsigned char poc_payload[] = {
  
[crash_input.bin.txt](https://github.com/user-attachments/files/28378854/crash_input.bin.txt)

};
Passing this buffer to ma_decoder_init_memory with ASan enabled will trigger the crash on the current master branch.