### PR TITLE
Set implementation file as Objective-C in CMake for Apple platforms (except macOS)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,6 +500,10 @@ if (UNIX)
     endif()
 endif()
 
+if(APPLE)
+    enable_language(OBJC)
+    set_source_files_properties(miniaudio.c PROPERTIES LANGUAGE OBJC)
+endif()
 
 # Static Libraries
 add_library(miniaudio

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,7 +500,10 @@ if (UNIX)
     endif()
 endif()
 
-if(APPLE)
+# APPLE is true for all Apple platforms. 
+# For macOS (MA_APPLE_DESKTOP, "Darwin" in CMake), the code uses CoreAudio that does not need Objective-C.
+# For the other Apple platforms, the code uses AVFoundation that requires Objective-C.
+if(APPLE AND NOT (CMAKE_SYSTEM_NAME STREQUAL "Darwin"))
     enable_language(OBJC)
     set_source_files_properties(miniaudio.c PROPERTIES LANGUAGE OBJC)
 endif()


### PR DESCRIPTION
This fixes CMake build targeting iOS due to usage of AVFoundation that requires Objective-C support. Otherwise, compiling as-is would result in several errors due to Objective-C specific syntax (e.g. `@class`). 