### PR TITLE
Fix ma_sound_get_cursor_in_seconds for data-source-backed sounds (#1144)

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -89012,9 +89012,12 @@ MA_API ma_result ma_sound_get_data_format(const ma_sound* pSound, ma_format* pFo
             return result;
         }
 
-        result = ma_data_source_get_channel_map(pSound->pDataSource, pChannelMap, channelMapCap);
-        if (result != MA_SUCCESS) {
-            return result;
+        /* Only query the channel map if the caller actually wants it. ma_data_source_get_channel_map() returns MA_INVALID_ARGS for a NULL channel map, but callers such as ma_sound_get_cursor_in_seconds() pass NULL when they only need the sample rate. This mirrors the guard used in the non-data-source branch above (see #1144). */
+        if (pChannelMap != NULL) {
+            result = ma_data_source_get_channel_map(pSound->pDataSource, pChannelMap, channelMapCap);
+            if (result != MA_SUCCESS) {
+                return result;
+            }
         }
 
         return MA_SUCCESS;


### PR DESCRIPTION
Fixes #1144.

### Problem

On `dev-0.12`, `ma_sound_get_cursor_in_seconds()` returns `MA_INVALID_ARGS` for every data-source-backed sound, so the cursor can never be read in seconds.

`dev-0.12` split channel-map retrieval out of `ma_data_source_get_data_format` into `ma_data_source_get_channel_map`, which returns `MA_INVALID_ARGS` for a NULL channel map. But the data-source branch of `ma_sound_get_data_format` calls it unconditionally, while callers that only want the sample rate pass `pChannelMap == NULL` (e.g. `ma_sound_get_cursor_in_seconds` calls `ma_sound_get_data_format(pSound, NULL, NULL, &sampleRate, NULL, 0)`). The sibling non-data-source branch already guards this with `if (pChannelMap != NULL)`; the data-source branch does not. `master`/`dev` are unaffected (there the branch is a single tolerant `ma_data_source_get_data_format` call), so this is a `dev-0.12` regression.

### Fix

Guard the `ma_data_source_get_channel_map` call with `if (pChannelMap != NULL)`, mirroring the non-data-source branch.

### Verification

Headless repro (engine `noDevice` mode + a `ma_waveform` data source, no audio hardware):

```c
ma_sound_init_from_data_source(&engine, &waveform, 0, NULL, NULL, &sound);
float cursor;
ma_result r = ma_sound_get_cursor_in_seconds(&sound, &cursor);
```

`gcc -I. repro.c -lm -lpthread -ldl` (compiles in ~3s, no third-party deps):
- before the fix: `r == MA_INVALID_ARGS (-2)`
- after the fix: `r == MA_SUCCESS (0)`

The WITH-channel-map path (`ma_sound_get_data_format` with a non-NULL channel map) is unchanged.

Base is `dev-0.12` since the regression is specific to that branch.
