### PR TITLE
Fixed inverted check in `ma_device_op_queue_uninit`

### DIFF
--- a/miniaudio.h
+++ b/miniaudio.h
@@ -50031,7 +50031,7 @@ MA_API ma_result ma_device_op_queue_init(ma_device_op_queue* pQueue)
 
 MA_API void ma_device_op_queue_uninit(ma_device_op_queue* pQueue)
 {
-    if (pQueue != NULL) {
+    if (pQueue == NULL) {
         return;
     }
 


### PR DESCRIPTION
The check for `NULL` is inverted in `ma_device_op_queue_uninit`. It returns if `pQueue != NULL`, and uninitializes poitentially `NULL` queue object.